### PR TITLE
Add expense routes and DB model

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2'
-import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import { integer, numeric, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 
 export const users = pgTable('users', {
   id: text('id')
@@ -32,5 +32,19 @@ export const goalCompletions = pgTable('goal_completions', {
   goalId: text('goal_id')
     .references(() => goals.id)
     .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
+export const expenses = pgTable('expenses', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  userId: text('user_id')
+    .references(() => users.id)
+    .notNull(),
+  title: text('title').notNull(),
+  payTo: text('pay_to').notNull(),
+  amount: numeric('amount', { precision: 10, scale: 2 }).notNull(),
+  dueDate: timestamp('due_date', { withTimezone: true }).notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/api/src/functions/create-expense.ts
+++ b/api/src/functions/create-expense.ts
@@ -1,0 +1,25 @@
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface CreateExpenseRequest {
+  userId: string
+  title: string
+  payTo: string
+  amount: number
+  dueDate: Date
+}
+
+export async function createExpense({
+  userId,
+  title,
+  payTo,
+  amount,
+  dueDate,
+}: CreateExpenseRequest) {
+  const [expense] = await db
+    .insert(expenses)
+    .values({ userId, title, payTo, amount, dueDate })
+    .returning()
+
+  return { expense }
+}

--- a/api/src/functions/get-expense.ts
+++ b/api/src/functions/get-expense.ts
@@ -1,0 +1,18 @@
+import { and, eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface GetExpenseRequest {
+  id: string
+  userId: string
+}
+
+export async function getExpense({ id, userId }: GetExpenseRequest) {
+  const [expense] = await db
+    .select()
+    .from(expenses)
+    .where(and(eq(expenses.id, id), eq(expenses.userId, userId)))
+
+  return { expense }
+}

--- a/api/src/functions/list-expenses.ts
+++ b/api/src/functions/list-expenses.ts
@@ -1,0 +1,14 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface ListExpensesRequest {
+  userId: string
+}
+
+export async function listExpenses({ userId }: ListExpensesRequest) {
+  const result = await db.select().from(expenses).where(eq(expenses.userId, userId))
+
+  return { expenses: result }
+}

--- a/api/src/http/routes/create-expense.ts
+++ b/api/src/http/routes/create-expense.ts
@@ -1,0 +1,36 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { createExpense } from '../../functions/create-expense'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const createExpenseRoute: FastifyPluginAsyncZod = async app => {
+  app.post(
+    '/expenses',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'Create an expense',
+        operationId: 'createExpense',
+        body: z.object({
+          title: z.string(),
+          payTo: z.string(),
+          amount: z.number(),
+          dueDate: z.coerce.date(),
+        }),
+        response: {
+          201: z.null(),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { title, payTo, amount, dueDate } = request.body
+      const userId = request.user.sub
+
+      await createExpense({ userId, title, payTo, amount, dueDate })
+
+      return reply.status(201).send()
+    }
+  )
+}

--- a/api/src/http/routes/get-expense.ts
+++ b/api/src/http/routes/get-expense.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { getExpense } from '../../functions/get-expense'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const getExpenseRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/expenses/:id',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'Get an expense by id',
+        operationId: 'getExpense',
+        params: z.object({
+          id: z.string(),
+        }),
+        response: {
+          200: z.object({
+            expense: z
+              .object({
+                id: z.string(),
+                userId: z.string(),
+                title: z.string(),
+                payTo: z.string(),
+                amount: z.number(),
+                dueDate: z.date(),
+                createdAt: z.date(),
+              })
+              .nullable(),
+          }),
+        },
+      },
+    },
+    async request => {
+      const { id } = request.params
+      const userId = request.user.sub
+
+      const { expense } = await getExpense({ id, userId })
+
+      return { expense }
+    }
+  )
+}

--- a/api/src/http/routes/list-expenses.ts
+++ b/api/src/http/routes/list-expenses.ts
@@ -1,0 +1,41 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { listExpenses } from '../../functions/list-expenses'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const listExpensesRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/expenses',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'List all expenses',
+        operationId: 'listExpenses',
+        response: {
+          200: z.object({
+            expenses: z.array(
+              z.object({
+                id: z.string(),
+                userId: z.string(),
+                title: z.string(),
+                payTo: z.string(),
+                amount: z.number(),
+                dueDate: z.date(),
+                createdAt: z.date(),
+              })
+            ),
+          }),
+        },
+      },
+    },
+    async request => {
+      const userId = request.user.sub
+
+      const { expenses } = await listExpenses({ userId })
+
+      return { expenses }
+    }
+  )
+}

--- a/api/src/http/server.ts
+++ b/api/src/http/server.ts
@@ -16,8 +16,11 @@ import { env } from '../env'
 import { createCompletionRoute } from './routes/create-completion'
 import { createGoalRoute } from './routes/create-goal'
 import { createNewUserRoute } from './routes/create-new-user'
+import { createExpenseRoute } from './routes/create-expense'
 import { getPendingGoalsRoute } from './routes/get-pending-goals'
+import { getExpenseRoute } from './routes/get-expense'
 import { getWeekSummaryRoute } from './routes/get-week-summary'
+import { listExpensesRoute } from './routes/list-expenses'
 import { signInRoute } from './routes/sigin-in'
 import { validateTokenRoute } from './routes/validate-token'
 
@@ -53,6 +56,9 @@ app.register(createCompletionRoute)
 app.register(getPendingGoalsRoute)
 app.register(getWeekSummaryRoute)
 app.register(createNewUserRoute)
+app.register(createExpenseRoute)
+app.register(getExpenseRoute)
+app.register(listExpensesRoute)
 app.register(validateTokenRoute)
 app.register(signInRoute)
 


### PR DESCRIPTION
## Summary
- add `expenses` table and functions to handle expenses
- create routes for creating, retrieving and listing expenses
- register new routes in API server

## Testing
- `npx biome format src/db/schema.ts src/http/server.ts src/functions/create-expense.ts src/functions/get-expense.ts src/functions/list-expenses.ts src/http/routes/create-expense.ts src/http/routes/get-expense.ts src/http/routes/list-expenses.ts --write`
- `npm run dbd:generate` *(fails: DATABASE_URL undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688a3c82f4088333a13693771a64ab55