### PR TITLE
Add house scoping and expense form

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -1,6 +1,16 @@
 import { createId } from '@paralleldrive/cuid2'
 import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 
+export const houses = pgTable('houses', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})
+
 export const users = pgTable('users', {
   id: text('id')
     .primaryKey()
@@ -10,6 +20,9 @@ export const users = pgTable('users', {
   phone: text('phone').notNull(),
   ddd: text('phone').notNull(),
   avatarUrl: text('avatar_url').notNull(),
+  houseId: text('house_id')
+    .notNull()
+    .references(() => houses.id),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 
@@ -32,5 +45,22 @@ export const goalCompletions = pgTable('goal_completions', {
   goalId: text('goal_id')
     .references(() => goals.id)
     .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
+export const expenses = pgTable('expenses', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  title: text('title').notNull(),
+  ownerId: text('owner_id')
+    .notNull()
+    .references(() => users.id),
+  payToId: text('pay_to_id')
+    .notNull()
+    .references(() => users.id),
+  amount: integer('amount').notNull(),
+  dueDate: timestamp('due_date', { withTimezone: true }).notNull(),
+  description: text('description'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/api/src/db/seed.ts
+++ b/api/src/db/seed.ts
@@ -1,12 +1,18 @@
 import dayjs from 'dayjs'
 
 import { client, db } from '.'
-import { goalCompletions, goals, users } from './schema'
+import { goalCompletions, goals, houses, users } from './schema'
 
 async function seed() {
   await db.delete(goals)
   await db.delete(goalCompletions)
   await db.delete(users)
+  await db.delete(houses)
+
+  const [house] = await db
+    .insert(houses)
+    .values({ name: 'My House' })
+    .returning()
 
   const [user] = await db
     .insert(users)
@@ -17,6 +23,7 @@ async function seed() {
         email: 'fagner.egomes@gmail.com',
         phone: '5511999999999',
         ddd: '11',
+        houseId: house.id,
       },
       {
         name: 'Diego Fernandes',
@@ -24,6 +31,7 @@ async function seed() {
         email: 'g9L3N@example.com',
         phone: '5511999999999',
         ddd: '11',
+        houseId: house.id,
       },
     ])
     .returning()

--- a/api/src/functions/create-expense.ts
+++ b/api/src/functions/create-expense.ts
@@ -1,0 +1,29 @@
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface CreateExpenseRequest {
+  title: string
+  ownerId: string
+  payToId: string
+  amount: number
+  dueDate: Date
+  description?: string
+}
+
+export async function createExpense({
+  title,
+  ownerId,
+  payToId,
+  amount,
+  dueDate,
+  description,
+}: CreateExpenseRequest) {
+  const result = await db
+    .insert(expenses)
+    .values({ title, ownerId, payToId, amount, dueDate, description })
+    .returning()
+
+  const expense = result[0]
+
+  return { expense }
+}

--- a/api/src/functions/get-expense.ts
+++ b/api/src/functions/get-expense.ts
@@ -1,0 +1,16 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface GetExpenseRequest {
+  id: string
+}
+
+export async function getExpense({ id }: GetExpenseRequest) {
+  const result = await db.select().from(expenses).where(eq(expenses.id, id))
+
+  const expense = result[0]
+
+  return { expense }
+}

--- a/api/src/functions/get-user.ts
+++ b/api/src/functions/get-user.ts
@@ -4,13 +4,19 @@ import { db } from '../db'
 import { users } from '../db/schema'
 
 interface GetUserRequest {
+  id?: string
   email?: string
   phone?: string
 }
 
-export async function getUser({ email, phone }: GetUserRequest) {
-  if (!email && !phone) {
-    throw new Error('Informe um email ou telefone')
+export async function getUser({ id, email, phone }: GetUserRequest) {
+  if (!id && !email && !phone) {
+    throw new Error('Informe um identificador de usuário')
+  }
+
+  if (id) {
+    const result = await db.select().from(users).where(eq(users.id, id))
+    return result[0] ? { ...result[0] } : undefined
   }
 
   if (email) {

--- a/api/src/functions/list-expenses.ts
+++ b/api/src/functions/list-expenses.ts
@@ -1,0 +1,17 @@
+import { eq, or } from 'drizzle-orm'
+
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface ListExpensesRequest {
+  userId: string
+}
+
+export async function listExpenses({ userId }: ListExpensesRequest) {
+  const result = await db
+    .select()
+    .from(expenses)
+    .where(or(eq(expenses.ownerId, userId), eq(expenses.payToId, userId)))
+
+  return { expenses: result }
+}

--- a/api/src/functions/list-users.ts
+++ b/api/src/functions/list-users.ts
@@ -1,0 +1,17 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { users } from '../db/schema'
+
+interface ListUsersRequest {
+  houseId: string
+}
+
+export async function listUsers({ houseId }: ListUsersRequest) {
+  const result = await db
+    .select()
+    .from(users)
+    .where(eq(users.houseId, houseId))
+
+  return { users: result }
+}

--- a/api/src/http/routes/create-expense.ts
+++ b/api/src/http/routes/create-expense.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { createExpense } from '../../functions/create-expense'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const createExpenseRoute: FastifyPluginAsyncZod = async app => {
+  app.post(
+    '/expenses',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'Create an expense',
+        operationId: 'createExpense',
+        body: z.object({
+          title: z.string(),
+          payToId: z.string(),
+          amount: z.number(),
+          dueDate: z.string(),
+          description: z.string().optional(),
+        }),
+        response: {
+          201: z.null(),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { title, payToId, amount, dueDate, description } = request.body
+
+      const ownerId = request.user.sub
+
+      await createExpense({
+        title,
+        ownerId,
+        payToId,
+        amount,
+        dueDate: new Date(dueDate),
+        description,
+      })
+
+      return reply.status(201).send()
+    }
+  )
+}

--- a/api/src/http/routes/get-expense.ts
+++ b/api/src/http/routes/get-expense.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { getExpense } from '../../functions/get-expense'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const getExpenseRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/expenses/:expenseId',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'Get expense by id',
+        operationId: 'getExpense',
+        params: z.object({
+          expenseId: z.string(),
+        }),
+        response: {
+          200: z.object({
+            expense: z
+              .object({
+                id: z.string(),
+                title: z.string(),
+                ownerId: z.string(),
+                payToId: z.string(),
+                amount: z.number(),
+                dueDate: z.date(),
+                description: z.string().nullable(),
+                createdAt: z.date(),
+              })
+              .nullable(),
+          }),
+        },
+      },
+    },
+    async request => {
+      const { expenseId } = request.params
+
+      const { expense } = await getExpense({ id: expenseId })
+
+      return { expense: expense ?? null }
+    }
+  )
+}

--- a/api/src/http/routes/list-expenses.ts
+++ b/api/src/http/routes/list-expenses.ts
@@ -1,0 +1,42 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { listExpenses } from '../../functions/list-expenses'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const listExpensesRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/expenses',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'List expenses for authenticated user',
+        operationId: 'listExpenses',
+        response: {
+          200: z.object({
+            expenses: z.array(
+              z.object({
+                id: z.string(),
+                title: z.string(),
+                ownerId: z.string(),
+                payToId: z.string(),
+                amount: z.number(),
+                dueDate: z.date(),
+                description: z.string().nullable(),
+                createdAt: z.date(),
+              })
+            ),
+          }),
+        },
+      },
+    },
+    async request => {
+      const userId = request.user.sub
+
+      const { expenses } = await listExpenses({ userId })
+
+      return { expenses }
+    }
+  )
+}

--- a/api/src/http/routes/list-users.ts
+++ b/api/src/http/routes/list-users.ts
@@ -1,0 +1,48 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { listUsers } from '../../functions/list-users'
+import { getUser } from '../../functions/get-user'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const listUsersRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/users',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['User'],
+        description: 'List all users',
+        operationId: 'listUsers',
+        response: {
+          200: z.object({
+            users: z.array(
+              z.object({
+                id: z.string(),
+                name: z.string(),
+                email: z.string(),
+                phone: z.string(),
+                ddd: z.string(),
+                avatarUrl: z.string(),
+                createdAt: z.date(),
+              })
+            ),
+          }),
+        },
+      },
+    },
+    async request => {
+      const userId = request.user.sub
+
+      const user = await getUser({ id: userId })
+
+      if (!user) {
+        return { users: [] }
+      }
+
+      const { users } = await listUsers({ houseId: user.houseId })
+
+      return { users }
+    }
+  )
+}

--- a/api/src/http/server.ts
+++ b/api/src/http/server.ts
@@ -15,7 +15,11 @@ import {
 import { env } from '../env'
 import { createCompletionRoute } from './routes/create-completion'
 import { createGoalRoute } from './routes/create-goal'
+import { createExpenseRoute } from './routes/create-expense'
+import { getExpenseRoute } from './routes/get-expense'
+import { listExpensesRoute } from './routes/list-expenses'
 import { createNewUserRoute } from './routes/create-new-user'
+import { listUsersRoute } from './routes/list-users'
 import { getPendingGoalsRoute } from './routes/get-pending-goals'
 import { getWeekSummaryRoute } from './routes/get-week-summary'
 import { signInRoute } from './routes/sigin-in'
@@ -52,7 +56,11 @@ app.register(createGoalRoute)
 app.register(createCompletionRoute)
 app.register(getPendingGoalsRoute)
 app.register(getWeekSummaryRoute)
+app.register(createExpenseRoute)
+app.register(getExpenseRoute)
+app.register(listExpensesRoute)
 app.register(createNewUserRoute)
+app.register(listUsersRoute)
 app.register(validateTokenRoute)
 app.register(signInRoute)
 

--- a/web/src/pages/_app/(expense)/expenses.tsx
+++ b/web/src/pages/_app/(expense)/expenses.tsx
@@ -1,0 +1,107 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { http } from '@/http/client'
+
+interface User {
+  id: string
+  name: string
+}
+
+async function fetchUsers() {
+  return http<{ users: User[] }>('/users', { method: 'GET' })
+}
+
+interface ExpenseRequest {
+  title: string
+  payToId: string
+  amount: number
+  dueDate: string
+  description?: string
+}
+
+async function createExpense(data: ExpenseRequest) {
+  return http('/expenses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export const Route = createFileRoute('/_app/(expense)/expenses')({
+  component: Expenses,
+})
+
+function Expenses() {
+  const { data } = useQuery({ queryKey: ['users'], queryFn: fetchUsers })
+  const { mutateAsync, isPending } = useMutation({ mutationFn: createExpense })
+
+  const [title, setTitle] = useState('')
+  const [payToId, setPayToId] = useState('')
+  const [amount, setAmount] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [description, setDescription] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    await mutateAsync({
+      title,
+      payToId,
+      amount: Number(amount),
+      dueDate,
+      description: description || undefined,
+    })
+
+    setTitle('')
+    setPayToId('')
+    setAmount('')
+    setDueDate('')
+    setDescription('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <Input
+        placeholder="Título"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+      />
+      <Select value={payToId} onValueChange={setPayToId}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pagar para" />
+        </SelectTrigger>
+        <SelectContent>
+          {data?.users.map(user => (
+            <SelectItem key={user.id} value={user.id} className="rounded-lg">
+              {user.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Input
+        placeholder="Valor"
+        type="number"
+        value={amount}
+        onChange={e => setAmount(e.target.value)}
+      />
+      <Input
+        placeholder="Data de vencimento"
+        type="date"
+        value={dueDate}
+        onChange={e => setDueDate(e.target.value)}
+      />
+      <Input
+        placeholder="Descrição"
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+      />
+      <Button type="submit" disabled={isPending} isLoading={isPending}>
+        Cadastrar
+      </Button>
+    </form>
+  )
+}

--- a/web/src/routes/index.ts
+++ b/web/src/routes/index.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Rocket } from 'lucide-react'
+import { LayoutDashboard, Rocket, CreditCard } from 'lucide-react'
 
 export const data = {
   user: {
@@ -16,6 +16,11 @@ export const data = {
       title: 'Metas',
       url: '/goals',
       icon: Rocket,
+    },
+    {
+      title: 'Despesas',
+      url: '/expenses',
+      icon: CreditCard,
     },
   ],
 }


### PR DESCRIPTION
## Summary
- add `houses` table and relate users to a house
- update `/users` endpoint to return users from the same house as requester
- set ownerId automatically when creating an expense
- add seed data for houses
- show "Despesas" option in sidebar
- implement new `/expenses` page with form to create expenses

## Testing
- `npx -y biome@latest check api/src/db/schema.ts api/src/functions/get-user.ts api/src/functions/list-users.ts api/src/http/routes/create-expense.ts api/src/http/routes/list-users.ts api/src/db/seed.ts web/src/routes/index.ts web/src/pages/_app/'(expense)'/expenses.tsx`
- `npx tsc -p api/tsconfig.json --noEmit`
- `npx tsc -p web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688a3c82f4088333a13693771a64ab55