### PR TITLE
Add organization support and switcher

### DIFF
--- a/api/.migrations/0005_gigantic_lucky_pierre.sql
+++ b/api/.migrations/0005_gigantic_lucky_pierre.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "expenses" (
+	"id" text PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"owner_id" text NOT NULL,
+	"pay_to_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"amount" integer NOT NULL,
+	"due_date" timestamp with time zone NOT NULL,
+	"description" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organizations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_organizations" (
+	"user_id" text NOT NULL,
+	"organization_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "default_organization_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_pay_to_id_users_id_fk" FOREIGN KEY ("pay_to_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "expenses" ADD CONSTRAINT "expenses_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_organizations" ADD CONSTRAINT "user_organizations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_organizations" ADD CONSTRAINT "user_organizations_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_default_organization_id_organizations_id_fk" FOREIGN KEY ("default_organization_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;

--- a/api/.migrations/0006_same_sharon_carter.sql
+++ b/api/.migrations/0006_same_sharon_carter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "ddd" text NOT NULL;

--- a/api/.migrations/meta/0005_snapshot.json
+++ b/api/.migrations/meta/0005_snapshot.json
@@ -1,0 +1,392 @@
+{
+  "id": "b8b38715-5068-4db7-af7d-7203587f4ab8",
+  "prevId": "bb5b3975-ce6d-47e8-83bc-a7674adf79a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to_id": {
+          "name": "pay_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expenses_owner_id_users_id_fk": {
+          "name": "expenses_owner_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_pay_to_id_users_id_fk": {
+          "name": "expenses_pay_to_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "pay_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_organization_id_organizations_id_fk": {
+          "name": "expenses_organization_id_organizations_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_completions": {
+      "name": "goal_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_completions_goal_id_goals_id_fk": {
+          "name": "goal_completions_goal_id_goals_id_fk",
+          "tableFrom": "goal_completions",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_weekly_frequency": {
+          "name": "desired_weekly_frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organizations": {
+      "name": "user_organizations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organizations_user_id_users_id_fk": {
+          "name": "user_organizations_user_id_users_id_fk",
+          "tableFrom": "user_organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organizations_organization_id_organizations_id_fk": {
+          "name": "user_organizations_organization_id_organizations_id_fk",
+          "tableFrom": "user_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_organization_id": {
+          "name": "default_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_default_organization_id_organizations_id_fk": {
+          "name": "users_default_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "default_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/.migrations/meta/0006_snapshot.json
+++ b/api/.migrations/meta/0006_snapshot.json
@@ -1,0 +1,398 @@
+{
+  "id": "dd80c105-4975-4c02-b351-4d31c7a5f9a0",
+  "prevId": "b8b38715-5068-4db7-af7d-7203587f4ab8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pay_to_id": {
+          "name": "pay_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expenses_owner_id_users_id_fk": {
+          "name": "expenses_owner_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_pay_to_id_users_id_fk": {
+          "name": "expenses_pay_to_id_users_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "pay_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_organization_id_organizations_id_fk": {
+          "name": "expenses_organization_id_organizations_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_completions": {
+      "name": "goal_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_completions_goal_id_goals_id_fk": {
+          "name": "goal_completions_goal_id_goals_id_fk",
+          "tableFrom": "goal_completions",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_weekly_frequency": {
+          "name": "desired_weekly_frequency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_user_id_users_id_fk": {
+          "name": "goals_user_id_users_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organizations": {
+      "name": "user_organizations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organizations_user_id_users_id_fk": {
+          "name": "user_organizations_user_id_users_id_fk",
+          "tableFrom": "user_organizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organizations_organization_id_organizations_id_fk": {
+          "name": "user_organizations_organization_id_organizations_id_fk",
+          "tableFrom": "user_organizations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ddd": {
+          "name": "ddd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_organization_id": {
+          "name": "default_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_default_organization_id_organizations_id_fk": {
+          "name": "users_default_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "default_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/.migrations/meta/_journal.json
+++ b/api/.migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1753801962688,
       "tag": "0004_harsh_mongu",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1753896866780,
+      "tag": "0005_gigantic_lucky_pierre",
+      "breakpoints": true
     }
   ]
 }

--- a/api/.migrations/meta/_journal.json
+++ b/api/.migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1753896866780,
       "tag": "0005_gigantic_lucky_pierre",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1753897297208,
+      "tag": "0006_same_sharon_carter",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -1,6 +1,16 @@
 import { createId } from '@paralleldrive/cuid2'
 import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
 
+export const organizations = pgTable('organizations', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})
+
 export const users = pgTable('users', {
   id: text('id')
     .primaryKey()
@@ -10,7 +20,23 @@ export const users = pgTable('users', {
   phone: text('phone').notNull(),
   ddd: text('phone').notNull(),
   avatarUrl: text('avatar_url').notNull(),
+  /* Default organization used on signup */
+  defaultOrganizationId: text('default_organization_id')
+    .notNull()
+    .references(() => organizations.id),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
+export const userOrganizations = pgTable('user_organizations', {
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id),
+  organizationId: text('organization_id')
+    .notNull()
+    .references(() => organizations.id),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
 })
 
 export const goals = pgTable('goals', {
@@ -32,5 +58,25 @@ export const goalCompletions = pgTable('goal_completions', {
   goalId: text('goal_id')
     .references(() => goals.id)
     .notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
+export const expenses = pgTable('expenses', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  title: text('title').notNull(),
+  ownerId: text('owner_id')
+    .notNull()
+    .references(() => users.id),
+  payToId: text('pay_to_id')
+    .notNull()
+    .references(() => users.id),
+  organizationId: text('organization_id')
+    .notNull()
+    .references(() => organizations.id),
+  amount: integer('amount').notNull(),
+  dueDate: timestamp('due_date', { withTimezone: true }).notNull(),
+  description: text('description'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -6,9 +6,7 @@ export const organizations = pgTable('organizations', {
     .primaryKey()
     .$defaultFn(() => createId()),
   name: text('name').notNull(),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 
 export const users = pgTable('users', {
@@ -18,7 +16,7 @@ export const users = pgTable('users', {
   name: text('name').notNull(),
   email: text('email').notNull(),
   phone: text('phone').notNull(),
-  ddd: text('phone').notNull(),
+  ddd: text('ddd').notNull(),
   avatarUrl: text('avatar_url').notNull(),
   /* Default organization used on signup */
   defaultOrganizationId: text('default_organization_id')
@@ -34,9 +32,7 @@ export const userOrganizations = pgTable('user_organizations', {
   organizationId: text('organization_id')
     .notNull()
     .references(() => organizations.id),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 
 export const goals = pgTable('goals', {

--- a/api/src/db/seed.ts
+++ b/api/src/db/seed.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 
 import { client, db } from '.'
-import { goalCompletions, goals, organizations, users, userOrganizations } from './schema'
+import { goalCompletions, goals, organizations, userOrganizations, users } from './schema'
 
 async function seed() {
   await db.delete(goals)
@@ -10,10 +10,7 @@ async function seed() {
   await db.delete(userOrganizations)
   await db.delete(organizations)
 
-  const [org] = await db
-    .insert(organizations)
-    .values({ name: 'My House' })
-    .returning()
+  const [org] = await db.insert(organizations).values({ name: 'My House' }).returning()
 
   const [user, otherUser] = await db
     .insert(users)

--- a/api/src/db/seed.ts
+++ b/api/src/db/seed.ts
@@ -1,14 +1,21 @@
 import dayjs from 'dayjs'
 
 import { client, db } from '.'
-import { goalCompletions, goals, users } from './schema'
+import { goalCompletions, goals, organizations, users, userOrganizations } from './schema'
 
 async function seed() {
   await db.delete(goals)
   await db.delete(goalCompletions)
   await db.delete(users)
+  await db.delete(userOrganizations)
+  await db.delete(organizations)
 
-  const [user] = await db
+  const [org] = await db
+    .insert(organizations)
+    .values({ name: 'My House' })
+    .returning()
+
+  const [user, otherUser] = await db
     .insert(users)
     .values([
       {
@@ -17,6 +24,7 @@ async function seed() {
         email: 'fagner.egomes@gmail.com',
         phone: '5511999999999',
         ddd: '11',
+        defaultOrganizationId: org.id,
       },
       {
         name: 'Diego Fernandes',
@@ -24,9 +32,15 @@ async function seed() {
         email: 'g9L3N@example.com',
         phone: '5511999999999',
         ddd: '11',
+        defaultOrganizationId: org.id,
       },
     ])
     .returning()
+
+  await db.insert(userOrganizations).values([
+    { userId: user.id, organizationId: org.id },
+    { userId: otherUser.id, organizationId: org.id },
+  ])
 
   const result = await db
     .insert(goals)

--- a/api/src/functions/create-expense.ts
+++ b/api/src/functions/create-expense.ts
@@ -1,0 +1,39 @@
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface CreateExpenseRequest {
+  title: string
+  ownerId: string
+  payToId: string
+  organizationId: string
+  amount: number
+  dueDate: Date
+  description?: string
+}
+
+export async function createExpense({
+  title,
+  ownerId,
+  payToId,
+  organizationId,
+  amount,
+  dueDate,
+  description,
+}: CreateExpenseRequest) {
+  const result = await db
+    .insert(expenses)
+    .values({
+      title,
+      ownerId,
+      payToId,
+      organizationId,
+      amount,
+      dueDate,
+      description,
+    })
+    .returning()
+
+  const expense = result[0]
+
+  return { expense }
+}

--- a/api/src/functions/create-organization.ts
+++ b/api/src/functions/create-organization.ts
@@ -1,0 +1,21 @@
+import { db } from '../db'
+import { organizations, userOrganizations } from '../db/schema'
+
+interface CreateOrganizationRequest {
+  name: string
+  userId: string
+}
+
+export async function createOrganization({ name, userId }: CreateOrganizationRequest) {
+  const [organization] = await db
+    .insert(organizations)
+    .values({ name })
+    .returning()
+
+  await db.insert(userOrganizations).values({
+    userId,
+    organizationId: organization.id,
+  })
+
+  return { organization }
+}

--- a/api/src/functions/get-expense.ts
+++ b/api/src/functions/get-expense.ts
@@ -1,0 +1,16 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface GetExpenseRequest {
+  id: string
+}
+
+export async function getExpense({ id }: GetExpenseRequest) {
+  const result = await db.select().from(expenses).where(eq(expenses.id, id))
+
+  const expense = result[0]
+
+  return { expense }
+}

--- a/api/src/functions/get-user.ts
+++ b/api/src/functions/get-user.ts
@@ -4,13 +4,19 @@ import { db } from '../db'
 import { users } from '../db/schema'
 
 interface GetUserRequest {
+  id?: string
   email?: string
   phone?: string
 }
 
-export async function getUser({ email, phone }: GetUserRequest) {
-  if (!email && !phone) {
-    throw new Error('Informe um email ou telefone')
+export async function getUser({ id, email, phone }: GetUserRequest) {
+  if (!id && !email && !phone) {
+    throw new Error('Informe um identificador de usuário')
+  }
+
+  if (id) {
+    const result = await db.select().from(users).where(eq(users.id, id))
+    return result[0] ? { ...result[0] } : undefined
   }
 
   if (email) {

--- a/api/src/functions/list-expenses.ts
+++ b/api/src/functions/list-expenses.ts
@@ -1,0 +1,23 @@
+import { eq, or, and } from 'drizzle-orm'
+
+import { db } from '../db'
+import { expenses } from '../db/schema'
+
+interface ListExpensesRequest {
+  userId: string
+  organizationId: string
+}
+
+export async function listExpenses({ userId, organizationId }: ListExpensesRequest) {
+  const result = await db
+    .select()
+    .from(expenses)
+    .where(
+      and(
+        or(eq(expenses.ownerId, userId), eq(expenses.payToId, userId)),
+        eq(expenses.organizationId, organizationId),
+      ),
+    )
+
+  return { expenses: result }
+}

--- a/api/src/functions/list-organizations.ts
+++ b/api/src/functions/list-organizations.ts
@@ -1,0 +1,25 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { organizations, userOrganizations } from '../db/schema'
+
+interface ListOrganizationsRequest {
+  userId: string
+}
+
+export async function listOrganizations({ userId }: ListOrganizationsRequest) {
+  const result = await db
+    .select({
+      id: organizations.id,
+      name: organizations.name,
+      createdAt: organizations.createdAt,
+    })
+    .from(organizations)
+    .innerJoin(
+      userOrganizations,
+      eq(organizations.id, userOrganizations.organizationId),
+    )
+    .where(eq(userOrganizations.userId, userId))
+
+  return { organizations: result }
+}

--- a/api/src/functions/list-users.ts
+++ b/api/src/functions/list-users.ts
@@ -1,0 +1,26 @@
+import { eq } from 'drizzle-orm'
+
+import { db } from '../db'
+import { users, userOrganizations } from '../db/schema'
+
+interface ListUsersRequest {
+  organizationId: string
+}
+
+export async function listUsers({ organizationId }: ListUsersRequest) {
+  const result = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      phone: users.phone,
+      ddd: users.ddd,
+      avatarUrl: users.avatarUrl,
+      createdAt: users.createdAt,
+    })
+    .from(users)
+    .innerJoin(userOrganizations, eq(users.id, userOrganizations.userId))
+    .where(eq(userOrganizations.organizationId, organizationId))
+
+  return { users: result }
+}

--- a/api/src/http/routes/create-expense.ts
+++ b/api/src/http/routes/create-expense.ts
@@ -1,0 +1,47 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { createExpense } from '../../functions/create-expense'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const createExpenseRoute: FastifyPluginAsyncZod = async app => {
+  app.post(
+    '/expenses',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'Create an expense',
+        operationId: 'createExpense',
+        body: z.object({
+          title: z.string(),
+          payToId: z.string(),
+          organizationId: z.string(),
+          amount: z.number(),
+          dueDate: z.string(),
+          description: z.string().optional(),
+        }),
+        response: {
+          201: z.null(),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { title, payToId, organizationId, amount, dueDate, description } = request.body
+
+      const ownerId = request.user.sub
+
+      await createExpense({
+        title,
+        ownerId,
+        payToId,
+        organizationId,
+        amount,
+        dueDate: new Date(dueDate),
+        description,
+      })
+
+      return reply.status(201).send()
+    }
+  )
+}

--- a/api/src/http/routes/create-organization.ts
+++ b/api/src/http/routes/create-organization.ts
@@ -1,0 +1,35 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { createOrganization } from '../../functions/create-organization'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const createOrganizationRoute: FastifyPluginAsyncZod = async app => {
+  app.post(
+    '/organizations',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Organization'],
+        description: 'Create a new organization',
+        operationId: 'createOrganization',
+        body: z.object({
+          name: z.string(),
+        }),
+        response: {
+          201: z.object({
+            organizationId: z.string(),
+          }),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { name } = request.body
+      const userId = request.user.sub
+
+      const { organization } = await createOrganization({ name, userId })
+
+      return reply.status(201).send({ organizationId: organization.id })
+    },
+  )
+}

--- a/api/src/http/routes/get-expense.ts
+++ b/api/src/http/routes/get-expense.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { getExpense } from '../../functions/get-expense'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const getExpenseRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/expenses/:expenseId',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'Get expense by id',
+        operationId: 'getExpense',
+        params: z.object({
+          expenseId: z.string(),
+        }),
+        response: {
+          200: z.object({
+            expense: z
+              .object({
+                id: z.string(),
+                title: z.string(),
+                ownerId: z.string(),
+                payToId: z.string(),
+                amount: z.number(),
+                dueDate: z.date(),
+                description: z.string().nullable(),
+                createdAt: z.date(),
+              })
+              .nullable(),
+          }),
+        },
+      },
+    },
+    async request => {
+      const { expenseId } = request.params
+
+      const { expense } = await getExpense({ id: expenseId })
+
+      return { expense: expense ?? null }
+    }
+  )
+}

--- a/api/src/http/routes/list-expenses.ts
+++ b/api/src/http/routes/list-expenses.ts
@@ -1,0 +1,46 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { listExpenses } from '../../functions/list-expenses'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const listExpensesRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/expenses',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Expense'],
+        description: 'List expenses for authenticated user',
+        operationId: 'listExpenses',
+        querystring: z.object({
+          organizationId: z.string(),
+        }),
+        response: {
+          200: z.object({
+            expenses: z.array(
+              z.object({
+                id: z.string(),
+                title: z.string(),
+                ownerId: z.string(),
+                payToId: z.string(),
+                amount: z.number(),
+                dueDate: z.date(),
+                description: z.string().nullable(),
+                createdAt: z.date(),
+              })
+            ),
+          }),
+        },
+      },
+    },
+    async request => {
+      const userId = request.user.sub
+      const { organizationId } = request.query
+
+      const { expenses } = await listExpenses({ userId, organizationId })
+
+      return { expenses }
+    }
+  )
+}

--- a/api/src/http/routes/list-organizations.ts
+++ b/api/src/http/routes/list-organizations.ts
@@ -1,0 +1,37 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { listOrganizations } from '../../functions/list-organizations'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const listOrganizationsRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/organizations',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Organization'],
+        description: 'List organizations for authenticated user',
+        operationId: 'listOrganizations',
+        response: {
+          200: z.object({
+            organizations: z.array(
+              z.object({
+                id: z.string(),
+                name: z.string(),
+                createdAt: z.date(),
+              }),
+            ),
+          }),
+        },
+      },
+    },
+    async request => {
+      const userId = request.user.sub
+
+      const { organizations } = await listOrganizations({ userId })
+
+      return { organizations }
+    },
+  )
+}

--- a/api/src/http/routes/list-users.ts
+++ b/api/src/http/routes/list-users.ts
@@ -1,0 +1,52 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+
+import { listUsers } from '../../functions/list-users'
+import { getUser } from '../../functions/get-user'
+import { authenticateUserHook } from '../hooks/authenticate-user'
+
+export const listUsersRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/users',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['User'],
+        description: 'List all users in an organization',
+        operationId: 'listUsers',
+        querystring: z.object({
+          organizationId: z.string(),
+        }),
+        response: {
+          200: z.object({
+            users: z.array(
+              z.object({
+                id: z.string(),
+                name: z.string(),
+                email: z.string(),
+                phone: z.string(),
+                ddd: z.string(),
+                avatarUrl: z.string(),
+                createdAt: z.date(),
+              })
+            ),
+          }),
+        },
+      },
+    },
+    async request => {
+      const userId = request.user.sub
+      const { organizationId } = request.query
+
+      const user = await getUser({ id: userId })
+
+      if (!user) {
+        return { users: [] }
+      }
+
+      const { users } = await listUsers({ organizationId })
+
+      return { users }
+    }
+  )
+}

--- a/api/src/http/server.ts
+++ b/api/src/http/server.ts
@@ -15,7 +15,13 @@ import {
 import { env } from '../env'
 import { createCompletionRoute } from './routes/create-completion'
 import { createGoalRoute } from './routes/create-goal'
+import { createExpenseRoute } from './routes/create-expense'
+import { createOrganizationRoute } from './routes/create-organization'
+import { getExpenseRoute } from './routes/get-expense'
+import { listExpensesRoute } from './routes/list-expenses'
 import { createNewUserRoute } from './routes/create-new-user'
+import { listUsersRoute } from './routes/list-users'
+import { listOrganizationsRoute } from './routes/list-organizations'
 import { getPendingGoalsRoute } from './routes/get-pending-goals'
 import { getWeekSummaryRoute } from './routes/get-week-summary'
 import { signInRoute } from './routes/sigin-in'
@@ -52,7 +58,13 @@ app.register(createGoalRoute)
 app.register(createCompletionRoute)
 app.register(getPendingGoalsRoute)
 app.register(getWeekSummaryRoute)
+app.register(createExpenseRoute)
+app.register(getExpenseRoute)
+app.register(listExpensesRoute)
+app.register(createOrganizationRoute)
 app.register(createNewUserRoute)
+app.register(listUsersRoute)
+app.register(listOrganizationsRoute)
 app.register(validateTokenRoute)
 app.register(signInRoute)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { Toaster } from 'sonner'
 
 import { ThemeProvider } from './components/theme-provider.tsx'
+import { OrganizationProvider } from './hooks/use-organization'
 // Import the generated route tree
 import { routeTree } from './routeTree.gen.ts'
 
@@ -22,7 +23,9 @@ export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <RouterProvider router={router} />
+        <OrganizationProvider>
+          <RouterProvider router={router} />
+        </OrganizationProvider>
         <Toaster position="bottom-left" richColors />
       </ThemeProvider>
     </QueryClientProvider>

--- a/web/src/components/layout/sidebar/index.tsx
+++ b/web/src/components/layout/sidebar/index.tsx
@@ -2,6 +2,7 @@ import { IconInnerShadowTop } from '@tabler/icons-react'
 
 import { NavMain } from '@/components/layout/sidebar/nav-main'
 import { NavUser } from '@/components/layout/sidebar/nav-user'
+import { OrganizationSwitcher } from '@/components/organization-switcher'
 import {
   Sidebar,
   SidebarContent,
@@ -29,6 +30,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
+        <OrganizationSwitcher />
         <NavMain items={data.navMain} />
       </SidebarContent>
       <SidebarFooter>

--- a/web/src/components/organization-switcher.tsx
+++ b/web/src/components/organization-switcher.tsx
@@ -1,0 +1,28 @@
+import { useOrganization } from '@/hooks/use-organization'
+import { Button } from '@/components/ui/button'
+
+export function OrganizationSwitcher() {
+  const { organizationId, organizations, setOrganizationId } = useOrganization()
+
+  return (
+    <div className="p-2">
+      <select
+        className="w-full rounded border border-input bg-background p-2 text-sm"
+        value={organizationId ?? ''}
+        onChange={e => setOrganizationId(e.target.value)}
+      >
+        <option value="" disabled>
+          Selecione a organização
+        </option>
+        {organizations.map(org => (
+          <option key={org.id} value={org.id}>
+            {org.name}
+          </option>
+        ))}
+      </select>
+      <Button variant="outline" size="sm" className="mt-2 w-full">
+        Nova organização
+      </Button>
+    </div>
+  )
+}

--- a/web/src/hooks/use-organization.ts
+++ b/web/src/hooks/use-organization.ts
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { http } from '@/http/client'
+
+export type Organization = {
+  id: string
+  name: string
+  createdAt: string
+}
+
+type OrganizationContextProps = {
+  organizationId: string | null
+  setOrganizationId: (id: string) => void
+  organizations: Organization[]
+  setOrganizations: React.Dispatch<React.SetStateAction<Organization[]>>
+}
+
+const OrganizationContext = React.createContext<OrganizationContextProps | null>(null)
+
+export function OrganizationProvider({ children }: { children: React.ReactNode }) {
+  const [organizationId, setOrganizationId] = React.useState<string | null>(null)
+  const [organizations, setOrganizations] = React.useState<Organization[]>([])
+
+  React.useEffect(() => {
+    async function load() {
+      const { organizations } = await http<{ organizations: Organization[] }>(
+        '/organizations',
+        { method: 'GET' },
+      )
+      setOrganizations(organizations)
+      if (!organizationId && organizations.length > 0) {
+        setOrganizationId(organizations[0].id)
+      }
+    }
+
+    load().catch(console.error)
+  }, [])
+  return (
+    <OrganizationContext.Provider
+      value={{ organizationId, setOrganizationId, organizations, setOrganizations }}
+    >
+      {children}
+    </OrganizationContext.Provider>
+  )
+}
+
+export function useOrganization() {
+  const context = React.useContext(OrganizationContext)
+  if (!context) {
+    throw new Error('useOrganization must be used within OrganizationProvider')
+  }
+  return context
+}

--- a/web/src/pages/_app/(expense)/expenses.tsx
+++ b/web/src/pages/_app/(expense)/expenses.tsx
@@ -1,0 +1,118 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+
+import { useOrganization } from '@/hooks/use-organization'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { http } from '@/http/client'
+
+interface User {
+  id: string
+  name: string
+}
+
+async function fetchUsers(organizationId: string) {
+  return http<{ users: User[] }>(`/users?organizationId=${organizationId}`, { method: 'GET' })
+}
+
+interface ExpenseRequest {
+  title: string
+  payToId: string
+  amount: number
+  dueDate: string
+  description?: string
+}
+
+async function createExpense(data: ExpenseRequest & { organizationId: string }) {
+  return http('/expenses', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export const Route = createFileRoute('/_app/(expense)/expenses')({
+  component: Expenses,
+})
+
+function Expenses() {
+  const { organizationId } = useOrganization()
+  const { data } = useQuery({
+    queryKey: ['users', organizationId],
+    queryFn: () => fetchUsers(organizationId ?? ''),
+    enabled: !!organizationId,
+  })
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (payload: ExpenseRequest) =>
+      createExpense({ ...payload, organizationId: organizationId ?? '' }),
+  })
+
+  const [title, setTitle] = useState('')
+  const [payToId, setPayToId] = useState('')
+  const [amount, setAmount] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [description, setDescription] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!organizationId) return
+    await mutateAsync({
+      title,
+      payToId,
+      amount: Number(amount),
+      dueDate,
+      description: description || undefined,
+    })
+
+    setTitle('')
+    setPayToId('')
+    setAmount('')
+    setDueDate('')
+    setDescription('')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+      <Input
+        placeholder="Título"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+      />
+      <Select value={payToId} onValueChange={setPayToId}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pagar para" />
+        </SelectTrigger>
+        <SelectContent>
+          {data?.users.map(user => (
+            <SelectItem key={user.id} value={user.id} className="rounded-lg">
+              {user.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Input
+        placeholder="Valor"
+        type="number"
+        value={amount}
+        onChange={e => setAmount(e.target.value)}
+      />
+      <Input
+        placeholder="Data de vencimento"
+        type="date"
+        value={dueDate}
+        onChange={e => setDueDate(e.target.value)}
+      />
+      <Input
+        placeholder="Descrição"
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+      />
+      <Button type="submit" disabled={isPending} isLoading={isPending}>
+        Cadastrar
+      </Button>
+    </form>
+  )
+}

--- a/web/src/routes/index.ts
+++ b/web/src/routes/index.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Rocket } from 'lucide-react'
+import { LayoutDashboard, Rocket, CreditCard } from 'lucide-react'
 
 export const data = {
   user: {
@@ -16,6 +16,11 @@ export const data = {
       title: 'Metas',
       url: '/goals',
       icon: Rocket,
+    },
+    {
+      title: 'Despesas',
+      url: '/expenses',
+      icon: CreditCard,
     },
   ],
 }


### PR DESCRIPTION
## Summary
- rename `houses` table to `organizations`
- allow multiple organization memberships via `user_organizations`
- include organizationId in expenses
- expose endpoints to create and list organizations
- filter users and expenses by organization
- add organization switcher to sidebar

## Testing
- `npx -y biome@latest check ...` *(output suppressed)*
- `npx tsc -p api/tsconfig.json --noEmit`
- `npx tsc -p web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688a3c82f4088333a13693771a64ab55