### PR TITLE
Switch organizations to zustand store

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -51,7 +51,8 @@
     "tailwindcss": "^4.1.11",
     "universal-cookie": "^8.0.1",
     "vaul": "^1.1.2",
-    "zod": "^4.0.10"
+    "zod": "^4.0.10",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.2",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,6 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { Toaster } from 'sonner'
 
 import { ThemeProvider } from './components/theme-provider.tsx'
-import { OrganizationProvider } from './hooks/use-organization'
 // Import the generated route tree
 import { routeTree } from './routeTree.gen.ts'
 
@@ -23,9 +22,7 @@ export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <OrganizationProvider>
-          <RouterProvider router={router} />
-        </OrganizationProvider>
+        <RouterProvider router={router} />
         <Toaster position="bottom-left" richColors />
       </ThemeProvider>
     </QueryClientProvider>

--- a/web/src/components/layout/sidebar/index.tsx
+++ b/web/src/components/layout/sidebar/index.tsx
@@ -1,47 +1,16 @@
-import { IconInnerShadowTop } from '@tabler/icons-react'
-import { AudioWaveform, Command, GalleryVerticalEnd } from 'lucide-react'
-
 import { NavMain } from '@/components/layout/sidebar/nav-main'
 import { NavUser } from '@/components/layout/sidebar/nav-user'
-import { OrganizationSwitcher } from '@/components/organization-switcher'
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@/components/ui/sidebar'
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader } from '@/components/ui/sidebar'
 import { data } from '@/routes'
 import { TeamSwitcher } from './team-switcher'
-
-const teams = [
-  {
-    name: 'Acme Inc',
-    logo: GalleryVerticalEnd,
-    plan: 'Enterprise',
-  },
-  {
-    name: 'Acme Corp.',
-    logo: AudioWaveform,
-    plan: 'Startup',
-  },
-  {
-    name: 'Evil Corp.',
-    logo: Command,
-    plan: 'Free',
-  },
-]
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar {...props}>
       <SidebarHeader>
-        <TeamSwitcher teams={teams} />
+        <TeamSwitcher />
       </SidebarHeader>
       <SidebarContent>
-        <OrganizationSwitcher />
         <NavMain items={data.navMain} />
       </SidebarContent>
       <SidebarFooter>

--- a/web/src/components/layout/sidebar/team-switcher.tsx
+++ b/web/src/components/layout/sidebar/team-switcher.tsx
@@ -7,7 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
@@ -18,23 +17,21 @@ import {
 } from '@/components/ui/sidebar'
 import { useOrganization } from '@/hooks/use-organization'
 
-interface Teams {
-  teams: {
-    name: string
-    logo: React.ComponentType
-    plan: string
-  }[]
-}
-
-export function TeamSwitcher({ teams }: Teams) {
+export function TeamSwitcher() {
   const { isMobile } = useSidebar()
-  const [activeTeam, setActiveTeam] = React.useState(teams[0])
-  const { organizationId, organizations, setOrganizationId } = useOrganization()
+  const { organizationId, organizations, setOrganizationId, createOrganization } =
+    useOrganization()
 
-  console.log(organizations)
-  if (!activeTeam) {
-    return null
+  const activeTeam = organizations.find(org => org.id === organizationId)
+
+  async function handleCreate() {
+    const name = window.prompt('Nome da organização')
+    if (!name) return
+    const result = await createOrganization({ data: { name } })
+    setOrganizationId(result.organizationId)
   }
+
+  if (!activeTeam) return null
 
   return (
     <SidebarMenu>
@@ -46,11 +43,10 @@ export function TeamSwitcher({ teams }: Teams) {
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
               <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
-                <activeTeam.logo className="size-4" />
+                {activeTeam.name.charAt(0)}
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{activeTeam.name}</span>
-                <span className="truncate text-xs">{activeTeam.plan}</span>
               </div>
               <ChevronsUpDown className="ml-auto" />
             </SidebarMenuButton>
@@ -61,26 +57,25 @@ export function TeamSwitcher({ teams }: Teams) {
             side={isMobile ? 'bottom' : 'right'}
             sideOffset={4}
           >
-            <DropdownMenuLabel className="text-muted-foreground text-xs">Teams</DropdownMenuLabel>
-            {teams.map((team, index) => (
+            <DropdownMenuLabel className="text-muted-foreground text-xs">Organizações</DropdownMenuLabel>
+            {organizations.map(org => (
               <DropdownMenuItem
-                key={team.name}
-                onClick={() => setActiveTeam(team)}
+                key={org.id}
+                onClick={() => setOrganizationId(org.id)}
                 className="gap-2 p-2"
               >
-                <div className="flex size-6 items-center justify-center rounded-md border">
-                  <team.logo />
+                <div className="flex size-6 items-center justify-center rounded-md border bg-transparent">
+                  {org.name.charAt(0)}
                 </div>
-                {team.name}
-                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                {org.name}
               </DropdownMenuItem>
             ))}
             <DropdownMenuSeparator />
-            <DropdownMenuItem className="gap-2 p-2">
+            <DropdownMenuItem className="gap-2 p-2" onClick={handleCreate}>
               <div className="flex size-6 items-center justify-center rounded-md border bg-transparent">
                 <Plus className="size-4" />
               </div>
-              <div className="text-muted-foreground font-medium">Add team</div>
+              <div className="text-muted-foreground font-medium">Nova organização</div>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
## Summary
- add zustand dependency
- manage organizations with a zustand store and tanstack query
- expose organization selection in team switcher
- simplify sidebar layout
- remove unused provider

## Testing
- `npx -y biome format web/src/hooks/use-organization.tsx web/src/components/layout/sidebar/team-switcher.tsx web/src/components/layout/sidebar/index.tsx web/src/App.tsx web/package.json`
- `npx -y biome lint web/src/hooks/use-organization.tsx web/src/components/layout/sidebar/team-switcher.tsx web/src/components/layout/sidebar/index.tsx web/src/App.tsx web/package.json`


------
https://chatgpt.com/codex/tasks/task_e_688a6204b9048333b596f671a8d184ae