### PR TITLE
Implement org slug store and invites

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -77,3 +77,16 @@ export const expenses = pgTable('expenses', {
   description: text('description'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
+
+export const invites = pgTable('invites', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  organizationId: text('organization_id')
+    .notNull()
+    .references(() => organizations.id),
+  email: text('email').notNull(),
+  token: text('token').notNull(),
+  acceptedAt: timestamp('accepted_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+})

--- a/api/src/functions/invite/accept-invite.ts
+++ b/api/src/functions/invite/accept-invite.ts
@@ -1,0 +1,24 @@
+import { eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { invites, userOrganizations } from '@/db/schema'
+
+interface AcceptInviteRequest {
+  token: string
+  userId: string
+}
+
+export async function acceptInvite({ token, userId }: AcceptInviteRequest) {
+  const [invite] = await db.select().from(invites).where(eq(invites.token, token)).limit(1)
+  if (!invite) {
+    throw new Error('Invite not found')
+  }
+
+  await db.insert(userOrganizations).values({
+    userId,
+    organizationId: invite.organizationId,
+  })
+
+  await db.update(invites).set({ acceptedAt: new Date() }).where(eq(invites.id, invite.id))
+
+  return { invite }
+}

--- a/api/src/functions/invite/create-invite.ts
+++ b/api/src/functions/invite/create-invite.ts
@@ -1,0 +1,29 @@
+import { createId } from '@paralleldrive/cuid2'
+import { db } from '@/db'
+import { invites } from '@/db/schema'
+import { getOrganizationBySlug } from '../organization/get-organization-by-slug'
+
+interface CreateInviteRequest {
+  email: string
+  organizationSlug: string
+}
+
+export async function createInvite({ email, organizationSlug }: CreateInviteRequest) {
+  const { organization } = await getOrganizationBySlug({ slug: organizationSlug })
+  if (!organization) {
+    throw new Error('Organization not found')
+  }
+
+  const token = createId()
+
+  const [invite] = await db
+    .insert(invites)
+    .values({
+      organizationId: organization.id,
+      email,
+      token,
+    })
+    .returning()
+
+  return { invite }
+}

--- a/api/src/http/routes/invite/accept-invite.ts
+++ b/api/src/http/routes/invite/accept-invite.ts
@@ -1,0 +1,26 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+import { acceptInvite } from '@/functions/invite/accept-invite'
+import { authenticateUserHook } from '@/http/hooks/authenticate-user'
+
+export const acceptInviteRoute: FastifyPluginAsyncZod = async app => {
+  app.post(
+    '/org/:slug/invites/:token/accept',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Invite'],
+        description: 'Accept organization invite',
+        operationId: 'acceptInvite',
+        params: z.object({ slug: z.string(), token: z.string() }),
+        response: { 200: z.null() },
+      },
+    },
+    async (request, reply) => {
+      const { token } = request.params
+      const userId = request.user.sub
+      await acceptInvite({ token, userId })
+      return reply.status(200).send()
+    },
+  )
+}

--- a/api/src/http/routes/invite/create-invite.ts
+++ b/api/src/http/routes/invite/create-invite.ts
@@ -1,0 +1,27 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+import { createInvite } from '@/functions/invite/create-invite'
+import { authenticateUserHook } from '@/http/hooks/authenticate-user'
+
+export const createInviteRoute: FastifyPluginAsyncZod = async app => {
+  app.post(
+    '/org/:slug/invites',
+    {
+      onRequest: [authenticateUserHook],
+      schema: {
+        tags: ['Invite'],
+        description: 'Create invite to organization',
+        operationId: 'createInvite',
+        params: z.object({ slug: z.string() }),
+        body: z.object({ email: z.string().email() }),
+        response: { 201: z.object({ token: z.string() }) },
+      },
+    },
+    async (request, reply) => {
+      const { slug } = request.params
+      const { email } = request.body
+      const { invite } = await createInvite({ email, organizationSlug: slug })
+      return reply.status(201).send({ token: invite.token })
+    },
+  )
+}

--- a/api/src/http/server.ts
+++ b/api/src/http/server.ts
@@ -26,6 +26,8 @@ import { createOrganizationRoute } from './routes/organization/create-organizati
 import { listOrganizationsRoute } from './routes/organization/list-organizations'
 import { createNewUserRoute } from './routes/user/create-new-user'
 import { listUsersRoute } from './routes/user/list-users'
+import { createInviteRoute } from './routes/invite/create-invite'
+import { acceptInviteRoute } from './routes/invite/accept-invite'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
 
@@ -65,6 +67,8 @@ app.register(createOrganizationRoute)
 app.register(createNewUserRoute)
 app.register(listUsersRoute)
 app.register(listOrganizationsRoute)
+app.register(createInviteRoute)
+app.register(acceptInviteRoute)
 app.register(validateTokenRoute)
 app.register(signInRoute)
 

--- a/web/package.json
+++ b/web/package.json
@@ -51,6 +51,7 @@
     "tailwindcss": "^4.1.11",
     "universal-cookie": "^8.0.1",
     "vaul": "^1.1.2",
+    "zustand": "^4.5.2",
     "zod": "^4.0.10"
   },
   "devDependencies": {

--- a/web/src/components/layout/sidebar/index.tsx
+++ b/web/src/components/layout/sidebar/index.tsx
@@ -3,15 +3,17 @@ import { NavUser } from '@/components/layout/sidebar/nav-user'
 import { TeamSwitcher } from '@/components/layout/sidebar/team-switcher'
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader } from '@/components/ui/sidebar'
 import { data } from '@/routes'
+import { useNavItems } from '@/routes/navigation'
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const navItems = useNavItems()
   return (
     <Sidebar {...props}>
       <SidebarHeader>
         <TeamSwitcher />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain items={navItems} />
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={data.user} />

--- a/web/src/hooks/use-active-organization.ts
+++ b/web/src/hooks/use-active-organization.ts
@@ -1,4 +1,6 @@
 import { useRouter, useRouterState } from '@tanstack/react-router'
+import { useEffect } from 'react'
+import { useOrgStore } from '../stores/org'
 
 /**
  * Read the organization slug from the current URL and provide helpers to change it.
@@ -6,12 +8,20 @@ import { useRouter, useRouterState } from '@tanstack/react-router'
 export function useActiveOrganization() {
   const router = useRouter()
   const pathname = useRouterState({ select: s => s.location.pathname })
-  const [, orgSlug] = pathname.split('/')
+  const { slug, setSlug } = useOrgStore()
+
+  useEffect(() => {
+    const [, urlSlug] = pathname.split('/')
+    if (urlSlug && urlSlug !== slug) {
+      setSlug(urlSlug)
+    }
+  }, [pathname, slug, setSlug])
 
   function setOrganization(newSlug: string) {
     const [, , ...rest] = pathname.split('/')
+    setSlug(newSlug)
     router.navigate({ to: `/${newSlug}/${rest.join('/')}` })
   }
 
-  return { orgSlug, setOrganization }
+  return { orgSlug: slug, setOrganization }
 }

--- a/web/src/hooks/use-sidebar.ts
+++ b/web/src/hooks/use-sidebar.ts
@@ -1,10 +1,10 @@
 import { useRouterState } from '@tanstack/react-router'
-
-import { data } from '@/routes'
+import { useNavItems } from '@/routes/navigation'
 
 export const useSidebar = () => {
   const router = useRouterState()
-  const route = data.navMain.find(route => route.url === router.location.pathname)
+  const items = useNavItems()
+  const route = items.find(r => r.url === router.location.pathname)
 
   return {
     route,

--- a/web/src/pages/_app/$org/(expense)/expenses.tsx
+++ b/web/src/pages/_app/$org/(expense)/expenses.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -17,30 +19,31 @@ export const Route = createFileRoute('/_app/$org/(expense)/expenses')({
   component: Expenses,
 })
 
+const schema = z.object({
+  title: z.string(),
+  payToId: z.string(),
+  amount: z.string(),
+  dueDate: z.string(),
+  description: z.string().optional(),
+})
+
+type FormValues = z.infer<typeof schema>
+
 function Expenses() {
-  const [title, setTitle] = useState('')
-  const [payToId, setPayToId] = useState('')
-  const [amount, setAmount] = useState('')
-  const [dueDate, setDueDate] = useState('')
-  const [description, setDescription] = useState('')
+  const form = useForm<FormValues>({ resolver: zodResolver(schema) })
 
   const { orgSlug } = useActiveOrganization()
   const { data, isPending } = useListExpenses(orgSlug)
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-
-    setTitle('')
-    setPayToId('')
-    setAmount('')
-    setDueDate('')
-    setDescription('')
+  async function handleSubmit(values: FormValues) {
+    console.log(values)
+    form.reset()
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
-      <Input placeholder="Título" value={title} onChange={e => setTitle(e.target.value)} />
-      <Select value={payToId} onValueChange={setPayToId}>
+    <form onSubmit={form.handleSubmit(handleSubmit)} className="flex flex-col gap-4 p-4">
+      <Input placeholder="Título" {...form.register('title')} />
+      <Select value={form.watch('payToId')} onValueChange={value => form.setValue('payToId', value)}>
         <SelectTrigger>
           <SelectValue placeholder="Pagar para" />
         </SelectTrigger>
@@ -52,23 +55,9 @@ function Expenses() {
           ))}
         </SelectContent>
       </Select>
-      <Input
-        placeholder="Valor"
-        type="number"
-        value={amount}
-        onChange={e => setAmount(e.target.value)}
-      />
-      <Input
-        placeholder="Data de vencimento"
-        type="date"
-        value={dueDate}
-        onChange={e => setDueDate(e.target.value)}
-      />
-      <Input
-        placeholder="Descrição"
-        value={description}
-        onChange={e => setDescription(e.target.value)}
-      />
+      <Input placeholder="Valor" type="number" {...form.register('amount')} />
+      <Input placeholder="Data de vencimento" type="date" {...form.register('dueDate')} />
+      <Input placeholder="Descrição" {...form.register('description')} />
       <Button type="submit" disabled={isPending} isLoading={isPending}>
         Cadastrar
       </Button>

--- a/web/src/pages/_app/$org/(goal)/-components/weekly-summary.tsx
+++ b/web/src/pages/_app/$org/(goal)/-components/weekly-summary.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import ptBR from 'dayjs/locale/pt-BR'
+import ptBR from 'dayjs/locale/pt-br'
 import { CheckCircle2, Plus } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'

--- a/web/src/pages/_app/$org/(user)/users.tsx
+++ b/web/src/pages/_app/$org/(user)/users.tsx
@@ -1,0 +1,69 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useActiveOrganization } from '@/hooks/use-active-organization'
+import { useListUsers } from '@/http/generated/api'
+import { getAuthToken } from '@/lib/auth'
+import { toast } from 'sonner'
+
+export const Route = createFileRoute('/_app/$org/(user)/users')({
+  component: Users,
+})
+
+function Users() {
+  const { orgSlug } = useActiveOrganization()
+  const { data } = useListUsers(orgSlug)
+  const [email, setEmail] = useState('')
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch(`/api/org/${orgSlug}/invites`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${getAuthToken()}`,
+      },
+      body: JSON.stringify({ email }),
+    })
+    if (res.ok) {
+      toast.success('Convite enviado!')
+      setEmail('')
+    } else {
+      toast.error('Erro ao enviar convite')
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <form onSubmit={handleInvite} className="flex gap-2">
+        <Input placeholder="E-mail" value={email} onChange={e => setEmail(e.target.value)} />
+        <Button type="submit">Convidar</Button>
+      </form>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Usuário</TableHead>
+            <TableHead>Email</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data?.users.map(user => (
+            <TableRow key={user.id}>
+              <TableCell className="flex items-center gap-2">
+                <Avatar className="h-8 w-8">
+                  <AvatarImage src={user.avatarUrl} />
+                  <AvatarFallback>{user.name.slice(0, 2)}</AvatarFallback>
+                </Avatar>
+                {user.name}
+              </TableCell>
+              <TableCell>{user.email}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AppLayoutRouteImport } from './pages/_app/layout'
 import { Route as AuthValidateLinkRouteImport } from './pages/_auth/validate-link'
 import { Route as AuthSignUpRouteImport } from './pages/_auth/sign-up'
 import { Route as AuthSignInRouteImport } from './pages/_auth/sign-in'
+import { Route as AppOrguserUsersRouteImport } from './pages/_app/$org/(user)/users'
 import { Route as AppOrggoalGoalsRouteImport } from './pages/_app/$org/(goal)/goals'
 import { Route as AppOrgexpenseExpensesRouteImport } from './pages/_app/$org/(expense)/expenses'
 import { Route as AppOrgdashboardDashboardRouteImport } from './pages/_app/$org/(dashboard)/dashboard'
@@ -41,6 +42,11 @@ const AuthSignInRoute = AuthSignInRouteImport.update({
   path: '/sign-in',
   getParentRoute: () => AuthLayoutRoute,
 } as any)
+const AppOrguserUsersRoute = AppOrguserUsersRouteImport.update({
+  id: '/$org/(user)/users',
+  path: '/$org/users',
+  getParentRoute: () => AppLayoutRoute,
+} as any)
 const AppOrggoalGoalsRoute = AppOrggoalGoalsRouteImport.update({
   id: '/$org/(goal)/goals',
   path: '/$org/goals',
@@ -65,6 +71,7 @@ export interface FileRoutesByFullPath {
   '/$org/dashboard': typeof AppOrgdashboardDashboardRoute
   '/$org/expenses': typeof AppOrgexpenseExpensesRoute
   '/$org/goals': typeof AppOrggoalGoalsRoute
+  '/$org/users': typeof AppOrguserUsersRoute
 }
 export interface FileRoutesByTo {
   '/sign-in': typeof AuthSignInRoute
@@ -73,6 +80,7 @@ export interface FileRoutesByTo {
   '/$org/dashboard': typeof AppOrgdashboardDashboardRoute
   '/$org/expenses': typeof AppOrgexpenseExpensesRoute
   '/$org/goals': typeof AppOrggoalGoalsRoute
+  '/$org/users': typeof AppOrguserUsersRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -84,6 +92,7 @@ export interface FileRoutesById {
   '/_app/$org/(dashboard)/dashboard': typeof AppOrgdashboardDashboardRoute
   '/_app/$org/(expense)/expenses': typeof AppOrgexpenseExpensesRoute
   '/_app/$org/(goal)/goals': typeof AppOrggoalGoalsRoute
+  '/_app/$org/(user)/users': typeof AppOrguserUsersRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -94,6 +103,7 @@ export interface FileRouteTypes {
     | '/$org/dashboard'
     | '/$org/expenses'
     | '/$org/goals'
+    | '/$org/users'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/sign-in'
@@ -102,6 +112,7 @@ export interface FileRouteTypes {
     | '/$org/dashboard'
     | '/$org/expenses'
     | '/$org/goals'
+    | '/$org/users'
   id:
     | '__root__'
     | '/_app'
@@ -112,6 +123,7 @@ export interface FileRouteTypes {
     | '/_app/$org/(dashboard)/dashboard'
     | '/_app/$org/(expense)/expenses'
     | '/_app/$org/(goal)/goals'
+    | '/_app/$org/(user)/users'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -156,6 +168,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthSignInRouteImport
       parentRoute: typeof AuthLayoutRoute
     }
+    '/_app/$org/(user)/users': {
+      id: '/_app/$org/(user)/users'
+      path: '/$org/users'
+      fullPath: '/$org/users'
+      preLoaderRoute: typeof AppOrguserUsersRouteImport
+      parentRoute: typeof AppLayoutRoute
+    }
     '/_app/$org/(goal)/goals': {
       id: '/_app/$org/(goal)/goals'
       path: '/$org/goals'
@@ -184,12 +203,14 @@ interface AppLayoutRouteChildren {
   AppOrgdashboardDashboardRoute: typeof AppOrgdashboardDashboardRoute
   AppOrgexpenseExpensesRoute: typeof AppOrgexpenseExpensesRoute
   AppOrggoalGoalsRoute: typeof AppOrggoalGoalsRoute
+  AppOrguserUsersRoute: typeof AppOrguserUsersRoute
 }
 
 const AppLayoutRouteChildren: AppLayoutRouteChildren = {
   AppOrgdashboardDashboardRoute: AppOrgdashboardDashboardRoute,
   AppOrgexpenseExpensesRoute: AppOrgexpenseExpensesRoute,
   AppOrggoalGoalsRoute: AppOrggoalGoalsRoute,
+  AppOrguserUsersRoute: AppOrguserUsersRoute,
 }
 
 const AppLayoutRouteWithChildren = AppLayoutRoute._addFileChildren(

--- a/web/src/routes/index.ts
+++ b/web/src/routes/index.ts
@@ -1,26 +1,7 @@
-import { CreditCard, LayoutDashboard, Rocket } from 'lucide-react'
-
 export const data = {
   user: {
     name: 'Fagner Gomes',
     email: 'fagner.egomes@gmail.com',
     avatar: '/avatars/shadcn.jpg',
   },
-  navMain: [
-    {
-      title: 'Dashboard',
-      url: '/dashboard',
-      icon: LayoutDashboard,
-    },
-    {
-      title: 'Metas',
-      url: '/goals',
-      icon: Rocket,
-    },
-    {
-      title: 'Despesas',
-      url: '/expenses',
-      icon: CreditCard,
-    },
-  ],
 }

--- a/web/src/routes/navigation.ts
+++ b/web/src/routes/navigation.ts
@@ -1,0 +1,14 @@
+import { CreditCard, LayoutDashboard, Rocket, Users } from 'lucide-react'
+import { useOrgStore } from '@/stores/org'
+
+const baseItems = [
+  { title: 'Dashboard', path: 'dashboard', icon: LayoutDashboard },
+  { title: 'Metas', path: 'goals', icon: Rocket },
+  { title: 'Despesas', path: 'expenses', icon: CreditCard },
+  { title: 'Usuários', path: 'users', icon: Users },
+]
+
+export function useNavItems() {
+  const slug = useOrgStore(s => s.slug)
+  return baseItems.map(item => ({ ...item, url: `/${slug}/${item.path}` }))
+}

--- a/web/src/stores/org.ts
+++ b/web/src/stores/org.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface OrgState {
+  slug: string
+  setSlug: (slug: string) => void
+}
+
+export const useOrgStore = create<OrgState>(set => ({
+  slug: '',
+  setSlug: slug => set({ slug }),
+}))


### PR DESCRIPTION
## Summary
- manage active organization slug via Zustand store
- update sidebar and navigation to use the slug
- refactor expenses page with react-hook-form
- list organization users and allow inviting by email
- implement invite create/accept endpoints on backend

## Testing
- `npx vite build` in `web`
- `npx tsc -b` in `web`
- `npx tsc --noEmit` in `api`


------
https://chatgpt.com/codex/tasks/task_e_688a8e27729c83339deada0176404985