### PR TITLE
Implement invite email flow

### DIFF
--- a/api/src/functions/invite/accept-invite.ts
+++ b/api/src/functions/invite/accept-invite.ts
@@ -13,6 +13,10 @@ export async function acceptInvite({ token, userId }: AcceptInviteRequest) {
     throw new Error('Invite not found')
   }
 
+  if (invite.acceptedAt) {
+    throw new Error('Invite already accepted')
+  }
+
   await db.insert(userOrganizations).values({
     userId,
     organizationId: invite.organizationId,

--- a/api/src/functions/invite/create-invite.ts
+++ b/api/src/functions/invite/create-invite.ts
@@ -1,7 +1,9 @@
 import { createId } from '@paralleldrive/cuid2'
 import { db } from '@/db'
 import { invites } from '@/db/schema'
+import { env } from '@/env'
 import { getOrganizationBySlug } from '../organization/get-organization-by-slug'
+import { sendInviteMail } from '../send-invite-mail'
 
 interface CreateInviteRequest {
   email: string
@@ -24,6 +26,11 @@ export async function createInvite({ email, organizationSlug }: CreateInviteRequ
       token,
     })
     .returning()
+
+  const url = new URL(`${env.WEB_URL}/invite`)
+  url.searchParams.set('token', token)
+
+  await sendInviteMail({ email, url: url.toString() })
 
   return { invite }
 }

--- a/api/src/functions/invite/get-invite.ts
+++ b/api/src/functions/invite/get-invite.ts
@@ -1,0 +1,26 @@
+import { eq } from 'drizzle-orm'
+import { db } from '@/db'
+import { invites, organizations } from '@/db/schema'
+
+interface GetInviteRequest {
+  token: string
+}
+
+export async function getInvite({ token }: GetInviteRequest) {
+  const [invite] = await db
+    .select({
+      id: invites.id,
+      email: invites.email,
+      organizationId: invites.organizationId,
+      token: invites.token,
+      acceptedAt: invites.acceptedAt,
+      createdAt: invites.createdAt,
+      organizationSlug: organizations.slug,
+    })
+    .from(invites)
+    .leftJoin(organizations, eq(invites.organizationId, organizations.id))
+    .where(eq(invites.token, token))
+    .limit(1)
+
+  return { invite }
+}

--- a/api/src/functions/send-invite-mail.ts
+++ b/api/src/functions/send-invite-mail.ts
@@ -1,0 +1,24 @@
+import nodemailer from 'nodemailer'
+
+interface SendInviteMailRequest {
+  email: string
+  url: string
+}
+
+export async function sendInviteMail({ email, url }: SendInviteMailRequest) {
+  const transporter = nodemailer.createTransport({
+    host: 'smtp.ethereal.email',
+    port: 587,
+    auth: {
+      user: 'peggie82@ethereal.email',
+      pass: 'Y1CREBUcRPZwBw46fr',
+    },
+  })
+
+  await transporter.sendMail({
+    from: '"House App" <houseapp@gmail.com>',
+    to: email,
+    subject: 'Convite para o House App',
+    html: `Clique <a href="${url}">aqui</a> para aceitar o convite`,
+  })
+}

--- a/api/src/http/routes/invite/get-invite.ts
+++ b/api/src/http/routes/invite/get-invite.ts
@@ -1,0 +1,37 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import z from 'zod'
+import { getInvite } from '@/functions/invite/get-invite'
+
+export const getInviteRoute: FastifyPluginAsyncZod = async app => {
+  app.get(
+    '/invites/:token',
+    {
+      schema: {
+        tags: ['Invite'],
+        description: 'Get invite by token',
+        operationId: 'getInvite',
+        params: z.object({ token: z.string() }),
+        response: {
+          200: z.object({
+            invite: z
+              .object({
+                id: z.string(),
+                email: z.string(),
+                organizationId: z.string(),
+                organizationSlug: z.string(),
+                token: z.string(),
+                acceptedAt: z.date().nullish(),
+                createdAt: z.date(),
+              })
+              .nullable(),
+          }),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { token } = request.params
+      const { invite } = await getInvite({ token })
+      return reply.status(200).send({ invite })
+    },
+  )
+}

--- a/api/src/http/server.ts
+++ b/api/src/http/server.ts
@@ -28,6 +28,7 @@ import { createNewUserRoute } from './routes/user/create-new-user'
 import { listUsersRoute } from './routes/user/list-users'
 import { createInviteRoute } from './routes/invite/create-invite'
 import { acceptInviteRoute } from './routes/invite/accept-invite'
+import { getInviteRoute } from './routes/invite/get-invite'
 
 const app = fastify().withTypeProvider<ZodTypeProvider>()
 
@@ -69,6 +70,7 @@ app.register(listUsersRoute)
 app.register(listOrganizationsRoute)
 app.register(createInviteRoute)
 app.register(acceptInviteRoute)
+app.register(getInviteRoute)
 app.register(validateTokenRoute)
 app.register(signInRoute)
 

--- a/web/src/http/invite.ts
+++ b/web/src/http/invite.ts
@@ -1,0 +1,17 @@
+import { http } from './client'
+
+export interface InviteResponse {
+  invite: {
+    id: string
+    email: string
+    organizationId: string
+    organizationSlug: string
+    token: string
+    acceptedAt: string | null
+    createdAt: string
+  } | null
+}
+
+export function getInvite(token: string) {
+  return http<InviteResponse>(`/invites/${token}`, { method: 'GET' })
+}

--- a/web/src/pages/_auth/validate-link.tsx
+++ b/web/src/pages/_auth/validate-link.tsx
@@ -29,10 +29,16 @@ function RouteComponent() {
         .then(({ valid }) => {
           if (valid) {
             setAuthToken(token)
+            const invite = localStorage.getItem('invite-token')
             setTimeout(() => {
               setIsLoading(false)
               setIsError(false)
-              navigate({ to: '/$org/goals', params: { org: 'my-house' } })
+              if (invite) {
+                localStorage.removeItem('invite-token')
+                navigate({ to: '/invite', search: { token: invite } })
+              } else {
+                navigate({ to: '/$org/goals', params: { org: 'my-house' } })
+              }
             }, 4000)
           } else {
             setIsLoading(false)

--- a/web/src/pages/invite.tsx
+++ b/web/src/pages/invite.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute, useSearch, useNavigate } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import z from 'zod'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { getInvite } from '@/http/invite'
+import { useAcceptInvite } from '@/http/generated/api'
+import { getAuthToken } from '@/lib/auth'
+
+export const Route = createFileRoute('/invite')({
+  component: InvitePage,
+  validateSearch: z => z.object({ token: z.string() }),
+})
+
+function InvitePage() {
+  const { token } = useSearch({ strict: false })
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [slug, setSlug] = useState('')
+  const authToken = getAuthToken()
+  const { mutateAsync: acceptInvite } = useAcceptInvite()
+
+  useEffect(() => {
+    if (!token) return
+    getInvite(token).then(res => {
+      if (res.invite) {
+        setEmail(res.invite.email)
+        setSlug(res.invite.organizationSlug)
+      } else {
+        toast.error('Convite inválido')
+      }
+    })
+  }, [token])
+
+  useEffect(() => {
+    if (authToken && token && slug) {
+      acceptInvite({ slug, token })
+        .then(() => {
+          toast.success('Convite aceito!')
+          navigate({ to: '/$org/goals', params: { org: slug } })
+        })
+        .catch(() => {
+          toast.info('Você já pertence a esta organização')
+          navigate({ to: '/$org/goals', params: { org: slug } })
+        })
+    }
+  }, [authToken, token, slug, acceptInvite, navigate])
+
+  useEffect(() => {
+    if (!authToken && token) {
+      localStorage.setItem('invite-token', token)
+    }
+  }, [authToken, token])
+
+  if (!authToken) {
+    return (
+      <div className="p-4 flex flex-col items-center gap-4">
+        <p>Convite para {slug || 'organização'} enviado para {email}</p>
+        <Button onClick={() => navigate({ to: '/sign-in' })}>Fazer login</Button>
+      </div>
+    )
+  }
+
+  return <div className="p-4">Processando convite...</div>
+}


### PR DESCRIPTION
## Summary
- add sendInviteMail function
- email invite token when creating invites
- avoid accepting invites twice
- auto-apply pending invites on sign in
- expose endpoint to fetch invite by token
- handle invite acceptance in frontend

## Testing
- `npx biome check .` *(fails: Found 12 errors in web, warnings in api)*

------
https://chatgpt.com/codex/tasks/task_e_688aa2fc5308833387c8a29da652ad43