### PR TITLE
Implement signup flow and expenses

### DIFF
--- a/api/src/db/seed.ts
+++ b/api/src/db/seed.ts
@@ -2,13 +2,23 @@ import dayjs from 'dayjs'
 import slugify from 'slugify'
 
 import { client, db } from '.'
-import { goalCompletions, goals, organizations, userOrganizations, users } from './schema'
+import {
+  goalCompletions,
+  goals,
+  organizations,
+  userOrganizations,
+  users,
+  expenses,
+  invites,
+} from './schema'
 
 async function seed() {
-  await db.delete(goals)
   await db.delete(goalCompletions)
-  await db.delete(users)
+  await db.delete(goals)
+  await db.delete(expenses)
+  await db.delete(invites)
   await db.delete(userOrganizations)
+  await db.delete(users)
   await db.delete(organizations)
 
   const [org, otherOrg] = await db
@@ -53,6 +63,27 @@ async function seed() {
     { userId: user.id, organizationId: org.id },
     { userId: otherUser.id, organizationId: org.id },
     { userId: thirdUser.id, organizationId: otherOrg.id },
+  ])
+
+  await db.insert(expenses).values([
+    {
+      title: 'Aluguel',
+      ownerId: user.id,
+      payToId: otherUser.id,
+      organizationId: org.id,
+      amount: 1000,
+      dueDate: dayjs().add(5, 'day').toDate(),
+      description: 'Mensalidade do apartamento',
+    },
+    {
+      title: 'Internet',
+      ownerId: otherUser.id,
+      payToId: thirdUser.id,
+      organizationId: otherOrg.id,
+      amount: 200,
+      dueDate: dayjs().add(3, 'day').toDate(),
+      description: 'Plano mensal',
+    },
   ])
 
   const result = await db

--- a/api/src/functions/user/create-new-user.ts
+++ b/api/src/functions/user/create-new-user.ts
@@ -1,7 +1,17 @@
+import slugify from 'slugify'
+
+import { db } from '@/db'
+import {
+  invites,
+  organizations,
+  userOrganizations,
+  users,
+} from '@/db/schema'
 import { env } from '@/env'
 import { AuthenticateUser } from '@/modules/auth'
 import { SendMail } from '../send-mail'
 import { SendWhats } from '../sendWhats'
+import { eq } from 'drizzle-orm'
 
 interface CreateNewUserRequest {
   name: string
@@ -9,10 +19,63 @@ interface CreateNewUserRequest {
   ddd: string
   phone: string
   avatarUrl: string
+  inviteToken?: string
 }
 
-export async function createNewUser({ name, email, ddd, phone, avatarUrl }: CreateNewUserRequest) {
-  const token = await AuthenticateUser(email)
+export async function createNewUser({
+  name,
+  email,
+  ddd,
+  phone,
+  avatarUrl,
+  inviteToken,
+}: CreateNewUserRequest) {
+  let organizationId: string | null = null
+
+  if (inviteToken) {
+    const [invite] = await db
+      .select()
+      .from(invites)
+      .where(eq(invites.token, inviteToken))
+      .limit(1)
+
+    if (!invite) {
+      throw new Error('Invite not found')
+    }
+
+    organizationId = invite.organizationId
+
+    await db
+      .update(invites)
+      .set({ acceptedAt: new Date() })
+      .where(eq(invites.id, invite.id))
+  } else {
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: `${name}'s House`, slug: slugify(`${name}-house`, { lower: true }) })
+      .returning()
+
+    organizationId = organization.id
+  }
+
+  const [user] = await db
+    .insert(users)
+    .values({
+      name,
+      email,
+      phone,
+      ddd,
+      avatarUrl,
+      defaultOrganizationId: organizationId,
+    })
+    .returning()
+
+  await db.insert(userOrganizations).values({
+    userId: user.id,
+    organizationId,
+  })
+
+  const token = await AuthenticateUser(user.id)
 
   const url = new URL(`${env.WEB_URL}/validate-link`)
   url.searchParams.set('token', token)

--- a/api/src/http/routes/user/create-new-user.ts
+++ b/api/src/http/routes/user/create-new-user.ts
@@ -23,24 +23,26 @@ export const createNewUserRoute: FastifyPluginAsyncZod = async app => {
             .max(10, 'Informe um telefone válido'),
           name: z.string('Informe o seu nome'),
           email: z.email('E-mail inválido'),
+          inviteToken: z.string().optional(),
         }),
         response: {
-          200: z.null(),
+          201: z.null(),
         },
       },
     },
     async (request, reply) => {
-      const { email, name, phone, ddd } = request.body
+      const { email, name, phone, ddd, inviteToken } = request.body
 
       await createNewUser({
         name,
         email,
         phone,
         ddd,
-        avatarUrl: 'https://robohash.org/$%7BMath.random().toString(36).slice(2)%7D?size=200x200',
+        avatarUrl: `https://robohash.org/${Math.random().toString(36).slice(2)}?size=200x200`,
+        inviteToken,
       })
 
-      return reply.status(200).send()
+      return reply.status(201).send()
     }
   )
 }

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -1,6 +1,8 @@
 import { Separator } from '@/components/ui/separator'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { useSidebar } from '@/hooks/use-sidebar'
+import { Bell } from 'lucide-react'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { ModeToggle } from '../mode-toggle'
 
 export function Header() {
@@ -13,6 +15,16 @@ export function Header() {
         <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
         <p>{route?.title}</p>
       </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="p-2" aria-label="Notificações">
+            <Bell className="size-5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="p-2 text-sm">
+          <p>Nenhuma notificação</p>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <ModeToggle />
     </header>
   )

--- a/web/src/http/generated/api.ts
+++ b/web/src/http/generated/api.ts
@@ -131,6 +131,7 @@ export type CreateNewUserBody = {
   name: string;
   /** @pattern ^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$ */
   email: string;
+  inviteToken?: string;
 };
 
 export type ListUsers200UsersItem = {
@@ -172,6 +173,7 @@ export type ValidateTokenBody = {
 
 export type ValidateToken200 = {
   valid: boolean;
+  slug?: string;
 };
 
 export type SignInBody = {

--- a/web/src/pages/_auth/sign-up.tsx
+++ b/web/src/pages/_auth/sign-up.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { useCreateNewUser } from '@/http/generated/api'
 
 export const Route = createFileRoute('/_auth/sign-up')({
   component: Index,
@@ -10,22 +15,53 @@ export const Route = createFileRoute('/_auth/sign-up')({
   }),
 })
 
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  ddd: z.string().min(2).max(2),
+  phone: z.string().min(8).max(10),
+})
+
+type FormValues = z.infer<typeof schema>
+
 function Index() {
   const navigate = useNavigate()
+  const { mutateAsync: createUser } = useCreateNewUser()
+
+  const form = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  async function handleSubmit(values: FormValues) {
+    const inviteToken = localStorage.getItem('invite-token') || undefined
+    try {
+      await createUser({ data: { ...values, inviteToken } })
+      toast.success('Cadastro realizado! Verifique seu e-mail.')
+      navigate({ to: '/sign-in' })
+    } catch {
+      toast.error('Erro ao cadastrar')
+    }
+  }
 
   return (
     <div className="justify-center items-center text-center flex flex-col">
-      <div className="flex flex-col gap-3 w-sm">
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="flex flex-col gap-3 w-sm"
+      >
         <h1>Fazer cadastro</h1>
-        <Input placeholder="Nome" />
-        <Input placeholder="Email" />
-        <Input placeholder="DDD" />
-        <Input placeholder="Telefone" />
-        <Button onClick={() => navigate({ to: '/sign-up' })}>Cadastrar</Button>
-        <Button className="mt-5" onClick={() => navigate({ to: '/sign-in' })} variant="outline">
+        <Input placeholder="Nome" {...form.register('name')} />
+        <Input placeholder="Email" {...form.register('email')} />
+        <Input placeholder="DDD" {...form.register('ddd')} />
+        <Input placeholder="Telefone" {...form.register('phone')} />
+        <Button type="submit">Cadastrar</Button>
+        <Button
+          type="button"
+          className="mt-5"
+          onClick={() => navigate({ to: '/sign-in' })}
+          variant="outline"
+        >
           Voltar
         </Button>
-      </div>
+      </form>
     </div>
   )
 }

--- a/web/src/pages/_auth/validate-link.tsx
+++ b/web/src/pages/_auth/validate-link.tsx
@@ -26,7 +26,7 @@ function RouteComponent() {
     setIsLoading(true)
     if (token) {
       validateToken({ data: { token } })
-        .then(({ valid }) => {
+        .then(({ valid, slug }) => {
           if (valid) {
             setAuthToken(token)
             const invite = localStorage.getItem('invite-token')
@@ -36,10 +36,10 @@ function RouteComponent() {
               if (invite) {
                 localStorage.removeItem('invite-token')
                 navigate({ to: '/invite', search: { token: invite } })
-              } else {
-                navigate({ to: '/$org/goals', params: { org: 'my-house' } })
+              } else if (slug) {
+                navigate({ to: '/$org/expenses', params: { org: slug } })
               }
-            }, 4000)
+            }, 1000)
           } else {
             setIsLoading(false)
             setIsError(true)


### PR DESCRIPTION
## Summary
- update user creation to handle invites and default organization
- return organization slug when validating token
- secure user list route with membership check
- seed example expenses data and cleanup order
- add notifications menu in header
- implement expense modal and listing
- enhance signup page with form + invite token handling
- redirect to organization slug after validating link

## Testing
- `yarn build` *(fails: Cannot find module 'node:path')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'drizzle-kit')*

------
https://chatgpt.com/codex/tasks/task_e_688b49e0ef0883339e66b7e0be1b985e