### PR TITLE
feat: add transaction filters with pagination

### DIFF
--- a/api/src/domain/transactions/list-transactions.ts
+++ b/api/src/domain/transactions/list-transactions.ts
@@ -1,4 +1,5 @@
-import { and, desc, eq, getTableColumns, sql } from 'drizzle-orm'
+import { and, desc, eq, getTableColumns, gte, lte, sql } from 'drizzle-orm'
+import dayjs from 'dayjs'
 
 import { db } from '@/db'
 import { transactions } from '@/db/schemas/transactions'
@@ -7,24 +8,76 @@ import { users } from '@/db/schemas/users'
 interface ListTransactionsRequest {
   userId: string
   orgId: string
+  type?: 'all' | 'income' | 'expense'
+  dateFrom?: Date
+  dateTo?: Date
+  page?: number
+  perPage?: number
 }
 
-export async function listTransactionsService({ userId, orgId }: ListTransactionsRequest) {
+export async function listTransactionsService({
+  userId,
+  orgId,
+  type = 'all',
+  dateFrom = dayjs().startOf('month').toDate(),
+  dateTo = dayjs().endOf('month').toDate(),
+  page = 1,
+  perPage = 10,
+}: ListTransactionsRequest) {
+  const offset = (page - 1) * perPage
+
+  const conditions = [
+    eq(transactions.ownerId, userId),
+    eq(transactions.organizationId, orgId),
+    gte(transactions.dueDate, dayjs(dateFrom).startOf('day').toDate()),
+    lte(transactions.dueDate, dayjs(dateTo).endOf('day').toDate()),
+  ]
+
+  if (type !== 'all') {
+    conditions.push(eq(transactions.type, type))
+  }
+
+  const where = and(...conditions)
+
+  const totalItemsResult = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(transactions)
+    .where(where)
+
+  const totalItems = Number(totalItemsResult[0]?.count ?? 0)
+  const totalPages = Math.ceil(totalItems / perPage)
+  const pagesRemaining = Math.max(0, totalPages - page)
+
   const result = await db
     .select({
       ...getTableColumns(transactions),
       payTo: users.name,
       status: sql /*sql*/`
-      CASE 
+      CASE
         WHEN ${transactions.paidAt} IS NOT NULL THEN 'paid'
-        WHEN ${transactions.paidAt} IS NULL AND ${transactions.dueDate}::date > CURRENT_DATE THEN 'scheduled'
+        WHEN ${transactions.paidAt} IS NULL AND ${transactions.dueDate}::date >= CURRENT_DATE THEN 'scheduled'
         ELSE 'overdue'
+      END`,
+      overdueDays: sql<number>`
+      CASE
+        WHEN ${transactions.paidAt} IS NULL AND ${transactions.dueDate}::date < CURRENT_DATE THEN
+          GREATEST(0, DATE_PART('day', CURRENT_DATE - ${transactions.dueDate}::date))
+        ELSE 0
       END`,
     })
     .from(transactions)
     .innerJoin(users, eq(transactions.payToId, users.id))
-    .where(and(eq(transactions.ownerId, userId), eq(transactions.organizationId, orgId)))
+    .where(where)
     .orderBy(desc(transactions.dueDate))
+    .limit(perPage)
+    .offset(offset)
 
-  return { transactions: result }
+  return {
+    transactions: result,
+    page,
+    perPage,
+    totalItems,
+    totalPages,
+    pagesRemaining,
+  }
 }

--- a/api/src/http/controllers/transaction/list-transactions.controller.ts
+++ b/api/src/http/controllers/transaction/list-transactions.controller.ts
@@ -1,15 +1,31 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
 
 import { listTransactionsService } from '@/domain/transactions/list-transactions'
-import type { ListTransactionSchemaParams } from '@/http/schemas/transaction/list-transactions.schema'
+import type {
+  ListTransactionSchemaParams,
+  ListTransactionSchemaQuery,
+} from '@/http/schemas/transaction/list-transactions.schema'
 
-type Req = FastifyRequest<{ Params: ListTransactionSchemaParams }>
+type Req = FastifyRequest<{
+  Params: ListTransactionSchemaParams
+  Querystring: ListTransactionSchemaQuery
+}>
 
 export async function listTransactionsController(request: Req, reply: FastifyReply) {
   const userId = request.user.sub
   const orgId = request.organization.id
 
-  const { transactions } = await listTransactionsService({ userId, orgId })
+  const { type, dateFrom, dateTo, page, perPage } = request.query
 
-  return reply.status(200).send({ transactions })
+  const result = await listTransactionsService({
+    userId,
+    orgId,
+    type,
+    dateFrom,
+    dateTo,
+    page,
+    perPage,
+  })
+
+  return reply.status(200).send(result)
 }

--- a/api/src/http/schemas/transaction/list-transactions.schema.ts
+++ b/api/src/http/schemas/transaction/list-transactions.schema.ts
@@ -7,11 +7,24 @@ export const listTransactionSchema = {
   description: 'List transactions for authenticated user',
   operationId: 'listTransactions',
   params: z.object({ slug: z.string().nonempty() }),
+  querystring: z.object({
+    type: z.enum(['all', 'income', 'expense']).default('all'),
+    dateFrom: z.coerce.date().optional(),
+    dateTo: z.coerce.date().optional(),
+    page: z.coerce.number().int().min(1).default(1),
+    perPage: z.coerce.number().int().min(1).default(10),
+  }),
   response: {
     200: z.object({
       transactions: z.array(transactionResponseSchema),
+      page: z.number(),
+      perPage: z.number(),
+      totalItems: z.number(),
+      totalPages: z.number(),
+      pagesRemaining: z.number(),
     }),
   },
 }
 
 export type ListTransactionSchemaParams = z.infer<typeof listTransactionSchema.params>
+export type ListTransactionSchemaQuery = z.infer<typeof listTransactionSchema.querystring>

--- a/api/src/http/schemas/transaction/shared/transaction-response.ts
+++ b/api/src/http/schemas/transaction/shared/transaction-response.ts
@@ -12,6 +12,7 @@ export const transactionResponseSchema = z.object({
   description: z.string().nullable(),
   createdAt: z.date(),
   status: z.enum(['paid', 'overdue', 'scheduled']),
+  overdueDays: z.number(),
   isRecurring: z.boolean(),
   recurrenceSelector: z.enum(['date', 'repeat']).optional(),
   recurrenceType: z.enum(['weekly', 'monthly', 'yearly']).optional(),

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -339,6 +339,35 @@
             "in": "path",
             "name": "slug",
             "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["all", "income", "expense"],
+              "default": "all"
+            },
+            "in": "query",
+            "name": "type"
+          },
+          {
+            "schema": { "type": "string", "format": "date-time" },
+            "in": "query",
+            "name": "dateFrom"
+          },
+          {
+            "schema": { "type": "string", "format": "date-time" },
+            "in": "query",
+            "name": "dateTo"
+          },
+          {
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
+            "in": "query",
+            "name": "page"
+          },
+          {
+            "schema": { "type": "integer", "minimum": 1, "default": 10 },
+            "in": "query",
+            "name": "perPage"
           }
         ],
         "responses": {
@@ -1253,6 +1282,9 @@
                               "scheduled"
                             ]
                           },
+                          "overdueDays": {
+                            "type": "integer"
+                          },
                           "isRecurring": {
                             "type": "boolean"
                           },
@@ -1293,17 +1325,28 @@
                           "description",
                           "createdAt",
                           "status",
+                          "overdueDays",
                           "isRecurring"
                         ],
                         "additionalProperties": false
                       }
                     }
                   },
-                  "required": [
-                    "transactions"
-                  ],
-                  "additionalProperties": false
-                }
+                  "page": { "type": "integer" },
+                  "perPage": { "type": "integer" },
+                  "totalItems": { "type": "integer" },
+                  "totalPages": { "type": "integer" },
+                  "pagesRemaining": { "type": "integer" }
+                },
+                "required": [
+                  "transactions",
+                  "page",
+                  "perPage",
+                  "totalItems",
+                  "totalPages",
+                  "pagesRemaining"
+                ],
+                "additionalProperties": false
               }
             }
           }

--- a/web/src/http/generated/api.ts
+++ b/web/src/http/generated/api.ts
@@ -2143,22 +2143,43 @@ export function useGetTransactionById<
 /**
  * List transactions for authenticated user
  */
-export const getListTransactionsUrl = (slug: string) => {
-  return `/org/${slug}/transactions`;
+export interface ListTransactionsParams {
+  type?: "all" | "income" | "expense";
+  dateFrom?: string;
+  dateTo?: string;
+  page?: number;
+  perPage?: number;
+}
+
+export const getListTransactionsUrl = (
+  slug: string,
+  params?: ListTransactionsParams,
+) => {
+  const url = new URL(`/org/${slug}/transactions`, "http://localhost");
+  if (params?.type) url.searchParams.append("type", params.type);
+  if (params?.dateFrom) url.searchParams.append("dateFrom", params.dateFrom);
+  if (params?.dateTo) url.searchParams.append("dateTo", params.dateTo);
+  if (params?.page) url.searchParams.append("page", String(params.page));
+  if (params?.perPage) url.searchParams.append("perPage", String(params.perPage));
+  return url.pathname + url.search;
 };
 
 export const listTransactions = async (
   slug: string,
+  params?: ListTransactionsParams,
   options?: RequestInit,
 ): Promise<ListTransactions200> => {
-  return http<ListTransactions200>(getListTransactionsUrl(slug), {
+  return http<ListTransactions200>(getListTransactionsUrl(slug, params), {
     ...options,
     method: "GET",
   });
 };
 
-export const getListTransactionsQueryKey = (slug?: string) => {
-  return [`/org/${slug}/transactions`] as const;
+export const getListTransactionsQueryKey = (
+  slug?: string,
+  params?: ListTransactionsParams,
+) => {
+  return [`/org/${slug}/transactions`, params] as const;
 };
 
 export const getListTransactionsQueryOptions = <
@@ -2166,24 +2187,26 @@ export const getListTransactionsQueryOptions = <
   TError = unknown,
 >(
   slug: string,
+  params?: ListTransactionsParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
         Awaited<ReturnType<typeof listTransactions>>,
         TError,
         TData
-      >
+      >,
     >;
     request?: SecondParameter<typeof http>;
   },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getListTransactionsQueryKey(slug);
+  const queryKey =
+    queryOptions?.queryKey ?? getListTransactionsQueryKey(slug, params);
 
   const queryFn: QueryFunction<
     Awaited<ReturnType<typeof listTransactions>>
-  > = ({ signal }) => listTransactions(slug, { signal, ...requestOptions });
+  > = ({ signal }) => listTransactions(slug, params, { signal, ...requestOptions });
 
   return {
     queryKey,
@@ -2207,95 +2230,24 @@ export function useListTransactions<
   TError = unknown,
 >(
   slug: string,
-  options: {
-    query: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listTransactions>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listTransactions>>,
-          TError,
-          Awaited<ReturnType<typeof listTransactions>>
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof http>;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-};
-export function useListTransactions<
-  TData = Awaited<ReturnType<typeof listTransactions>>,
-  TError = unknown,
->(
-  slug: string,
+  params?: ListTransactionsParams,
   options?: {
     query?: Partial<
       UseQueryOptions<
         Awaited<ReturnType<typeof listTransactions>>,
         TError,
         TData
-      >
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listTransactions>>,
-          TError,
-          Awaited<ReturnType<typeof listTransactions>>
-        >,
-        "initialData"
-      >;
-    request?: SecondParameter<typeof http>;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-};
-export function useListTransactions<
-  TData = Awaited<ReturnType<typeof listTransactions>>,
-  TError = unknown,
->(
-  slug: string,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listTransactions>>,
-        TError,
-        TData
-      >
+      >,
     >;
     request?: SecondParameter<typeof http>;
   },
   queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-};
-
-export function useListTransactions<
-  TData = Awaited<ReturnType<typeof listTransactions>>,
-  TError = unknown,
->(
-  slug: string,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listTransactions>>,
-        TError,
-        TData
-      >
-    >;
-    request?: SecondParameter<typeof http>;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & {
-  queryKey: DataTag<QueryKey, TData, TError>;
-} {
-  const queryOptions = getListTransactionsQueryOptions(slug, options);
+) {
+  const queryOptions = getListTransactionsQueryOptions(
+    slug,
+    params,
+    options,
+  );
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<
     TData,

--- a/web/src/http/generated/model/listTransactions200.ts
+++ b/web/src/http/generated/model/listTransactions200.ts
@@ -9,4 +9,9 @@ import type { ListTransactions200TransactionsItem } from "./listTransactions200T
 
 export type ListTransactions200 = {
   transactions: ListTransactions200TransactionsItem[];
+  page: number;
+  perPage: number;
+  totalItems: number;
+  totalPages: number;
+  pagesRemaining: number;
 };

--- a/web/src/http/generated/model/listTransactions200TransactionsItem.ts
+++ b/web/src/http/generated/model/listTransactions200TransactionsItem.ts
@@ -24,6 +24,7 @@ export type ListTransactions200TransactionsItem = {
   description: string | null;
   createdAt: string;
   status: ListTransactions200TransactionsItemStatus;
+  overdueDays: number;
   isRecurring: boolean;
   recurrenceSelector?: ListTransactions200TransactionsItemRecurrenceSelector;
   recurrenceType?: ListTransactions200TransactionsItemRecurrenceType;

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/footer.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/footer.tsx
@@ -4,8 +4,6 @@ import {
   IconChevronsLeft,
   IconChevronsRight,
 } from '@tabler/icons-react'
-import type { Table } from '@tanstack/react-table'
-
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -14,25 +12,34 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import type { ListTransactions200TransactionsItem } from '@/http/generated/model'
 
 interface TablePaginationProps {
-  table: Table<ListTransactions200TransactionsItem>
+  page: number
+  perPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  onPerPageChange: (perPage: number) => void
 }
 
-export function Footer({ table }: TablePaginationProps) {
+export function Footer({
+  page,
+  perPage,
+  totalPages,
+  onPageChange,
+  onPerPageChange,
+}: TablePaginationProps) {
   return (
     <div className="flex items-center justify-between px-4">
       <div className="flex w-full items-center gap-8 lg:w-fit">
         <div className=" items-center gap-2 lg:flex">
           <Select
-            value={`${table.getState().pagination.pageSize}`}
+            value={`${perPage}`}
             onValueChange={value => {
-              table.setPageSize(Number(value))
+              onPerPageChange(Number(value))
             }}
           >
             <SelectTrigger className="w-20" id="rows-per-page">
-              <SelectValue placeholder={table.getState().pagination.pageSize} />
+              <SelectValue placeholder={perPage} />
             </SelectTrigger>
             <SelectContent side="top">
               {[10, 20, 30, 40, 50].map(pageSize => (
@@ -44,14 +51,14 @@ export function Footer({ table }: TablePaginationProps) {
           </Select>
         </div>
         <div className="flex w-fit items-center justify-center text-sm font-medium">
-          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+          Page {page} of {totalPages}
         </div>
         <div className="ml-auto flex items-center gap-2 lg:ml-0">
           <Button
             variant="outline"
             className="hidden h-8 w-8 p-0 lg:flex"
-            onClick={() => table.setPageIndex(0)}
-            disabled={!table.getCanPreviousPage()}
+            onClick={() => onPageChange(1)}
+            disabled={page === 1}
           >
             <span className="sr-only">Go to first page</span>
             <IconChevronsLeft />
@@ -60,8 +67,8 @@ export function Footer({ table }: TablePaginationProps) {
             variant="outline"
             className="size-8"
             size="icon"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
+            onClick={() => onPageChange(page - 1)}
+            disabled={page === 1}
           >
             <span className="sr-only">Go to previous page</span>
             <IconChevronLeft />
@@ -70,8 +77,8 @@ export function Footer({ table }: TablePaginationProps) {
             variant="outline"
             className="size-8"
             size="icon"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
+            onClick={() => onPageChange(page + 1)}
+            disabled={page === totalPages}
           >
             <span className="sr-only">Go to next page</span>
             <IconChevronRight />
@@ -80,8 +87,8 @@ export function Footer({ table }: TablePaginationProps) {
             variant="outline"
             className="hidden size-8 lg:flex"
             size="icon"
-            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-            disabled={!table.getCanNextPage()}
+            onClick={() => onPageChange(totalPages)}
+            disabled={page === totalPages}
           >
             <span className="sr-only">Go to last page</span>
             <IconChevronsRight />

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/hook/use-table.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/hook/use-table.tsx
@@ -34,14 +34,17 @@ import { Label } from '@/components/ui/label'
 import type { ListTransactions200TransactionsItem } from '@/http/generated/model'
 import { DrawerEdit } from '../drawer-edit'
 
-export const useTable = (data: ListTransactions200TransactionsItem[]) => {
+export const useTable = (
+  data: ListTransactions200TransactionsItem[],
+  pageSize: number,
+) => {
   const [rowSelection, setRowSelection] = useState({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({ Pagamento: false })
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [sorting, setSorting] = useState<SortingState>([])
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 10,
+    pageSize,
   })
 
   const columns: ColumnDef<ListTransactions200TransactionsItem>[] = [
@@ -125,6 +128,11 @@ export const useTable = (data: ListTransactions200TransactionsItem[]) => {
       cell: ({ row }) => (
         <Label className="text-muted-foreground px-1.5">
           {dayjs(row.original.dueDate).format('DD/MM/YYYY')}
+          {row.original.status === 'overdue' && (
+            <span className="ml-2 text-red-600">
+              Vencida{row.original.overdueDays > 0 && ` há ${row.original.overdueDays} dias`}
+            </span>
+          )}
         </Label>
       ),
     },

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
@@ -1,19 +1,63 @@
-import type { ListTransactions200 } from '@/http/generated/model'
+import type {
+  ListTransactions200TransactionsItem,
+} from '@/http/generated/model'
 import { Footer } from './footer'
 import { useTable } from './hook/use-table'
 import { NavbarTable } from './navbar'
 import { TableView } from './table'
 
-interface Props extends ListTransactions200 {}
+interface Props {
+  transactions: ListTransactions200TransactionsItem[]
+  page: number
+  perPage: number
+  totalPages: number
+  type: 'all' | 'income' | 'expense'
+  dateFrom: string
+  dateTo: string
+  onTypeChange: (t: 'all' | 'income' | 'expense') => void
+  onDateFromChange: (d: string) => void
+  onDateToChange: (d: string) => void
+  onPageChange: (p: number) => void
+  onPerPageChange: (p: number) => void
+}
 
-export function TableLIstTransactions({ transactions }: Props) {
-  const { table } = useTable(transactions)
+export function TableLIstTransactions(props: Props) {
+  const {
+    transactions,
+    page,
+    perPage,
+    totalPages,
+    type,
+    dateFrom,
+    dateTo,
+    onTypeChange,
+    onDateFromChange,
+    onDateToChange,
+    onPageChange,
+    onPerPageChange,
+  } = props
+
+  const { table } = useTable(transactions, perPage)
 
   return (
     <div className="flex flex-col gap-4">
-      <NavbarTable table={table} />
+      <NavbarTable
+        table={table}
+        type={type}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onTypeChange={onTypeChange}
+        onDateFromChange={onDateFromChange}
+        onDateToChange={onDateToChange}
+      />
       <TableView table={table} />
-      <Footer table={table} />
+      <Footer
+        page={page}
+        perPage={perPage}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+        onPerPageChange={onPerPageChange}
+      />
     </div>
   )
 }

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/navbar.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/navbar.tsx
@@ -20,21 +20,50 @@ import { ModalNewTransaction } from '../modal-new-transaction'
 
 interface Props {
   table: Table<ListTransactions200TransactionsItem>
+  type: 'all' | 'income' | 'expense'
+  dateFrom: string
+  dateTo: string
+  onTypeChange: (t: 'all' | 'income' | 'expense') => void
+  onDateFromChange: (d: string) => void
+  onDateToChange: (d: string) => void
 }
 
-export function NavbarTable({ table }: Props) {
+export function NavbarTable({
+  table,
+  type,
+  dateFrom,
+  dateTo,
+  onTypeChange,
+  onDateFromChange,
+  onDateToChange,
+}: Props) {
   return (
-    <div className="flex items-center justify-between px-4 lg:px-6">
-      <Select defaultValue="all">
-        <SelectTrigger className="flex w-fit @4xl/main:hidden" id="view-selector">
-          <SelectValue placeholder="View" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">Todas</SelectItem>
-          <SelectItem value="expenses">Despesas</SelectItem>
-          <SelectItem value="incomes">Receitas</SelectItem>
-        </SelectContent>
-      </Select>
+    <div className="flex flex-col gap-2 px-4 lg:px-6 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        <Select value={type} onValueChange={onTypeChange}>
+          <SelectTrigger className="flex w-fit @4xl/main:hidden" id="view-selector">
+            <SelectValue placeholder="View" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todas</SelectItem>
+            <SelectItem value="expense">Despesas</SelectItem>
+            <SelectItem value="income">Receitas</SelectItem>
+          </SelectContent>
+        </Select>
+        <input
+          type="date"
+          value={dateFrom}
+          onChange={e => onDateFromChange(e.target.value)}
+          className="border rounded px-2 py-1 text-sm"
+        />
+        <span>-</span>
+        <input
+          type="date"
+          value={dateTo}
+          onChange={e => onDateToChange(e.target.value)}
+          className="border rounded px-2 py-1 text-sm"
+        />
+      </div>
 
       <div className="flex items-center gap-2">
         <DropdownMenu>

--- a/web/src/pages/_app/$org/(transactions)/transactions.tsx
+++ b/web/src/pages/_app/$org/(transactions)/transactions.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
+import dayjs from 'dayjs'
 import { File, Loader2 } from 'lucide-react'
+import { useState } from 'react'
 
 import { useActiveOrganization } from '@/hooks/use-active-organization'
 import { useListTransactions } from '@/http/generated/api'
@@ -11,16 +13,35 @@ export const Route = createFileRoute('/_app/$org/(transactions)/transactions')({
 
 function Transaction() {
   const { slug } = useActiveOrganization()
-  const { data: transactions, isPending } = useListTransactions(slug, {
-    query: {
-      maxPages: 1,
-      retry: false,
-      staleTime: 5 * 60 * 1000,
-      gcTime: 30 * 60 * 1000,
-      refetchOnWindowFocus: true,
-      select: d => d?.transactions ?? [],
+  const [type, setType] = useState<'all' | 'income' | 'expense'>('all')
+  const [dateFrom, setDateFrom] = useState(
+    dayjs().startOf('month').format('YYYY-MM-DD'),
+  )
+  const [dateTo, setDateTo] = useState(
+    dayjs().endOf('month').format('YYYY-MM-DD'),
+  )
+  const [page, setPage] = useState(1)
+  const [perPage, setPerPage] = useState(10)
+
+  const { data, isPending } = useListTransactions(
+    slug,
+    {
+      type,
+      dateFrom,
+      dateTo,
+      page,
+      perPage,
     },
-  })
+    {
+      query: {
+        maxPages: 1,
+        retry: false,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 30 * 60 * 1000,
+        refetchOnWindowFocus: true,
+      },
+    },
+  )
 
   if (isPending) {
     return (
@@ -31,7 +52,7 @@ function Transaction() {
     )
   }
 
-  if (!transactions?.length) {
+  if (!data?.transactions?.length) {
     return (
       <div className="flex flex-col h-screen items-center justify-center">
         <p className="text-zinc-500 mb-4">Nenhuma despesa cadastrada</p>
@@ -42,7 +63,32 @@ function Transaction() {
 
   return (
     <div className="mt-4">
-      <TableLIstTransactions transactions={transactions} />
+      <TableLIstTransactions
+        transactions={data.transactions}
+        page={data.page}
+        perPage={data.perPage}
+        totalPages={data.totalPages}
+        type={type}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        onTypeChange={t => {
+          setType(t)
+          setPage(1)
+        }}
+        onDateFromChange={d => {
+          setDateFrom(d)
+          setPage(1)
+        }}
+        onDateToChange={d => {
+          setDateTo(d)
+          setPage(1)
+        }}
+        onPageChange={p => setPage(p)}
+        onPerPageChange={p => {
+          setPerPage(p)
+          setPage(1)
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- extend list transactions service with type/date filters, pagination metadata and overdue days
- expose filter and pagination query parameters in API schema and swagger spec
- update frontend to handle filters, date range, and server-driven pagination with overdue indicators

## Testing
- `npm test` *(api)*
- `npm test` *(web)*

------
https://chatgpt.com/codex/tasks/task_e_689c9c6e6250833391ec7fcd5cfec231