### PR TITLE
feat: add hamburger menu skeleton

### DIFF
--- a/web/src/components/layout/hamburger-menu.tsx
+++ b/web/src/components/layout/hamburger-menu.tsx
@@ -1,0 +1,39 @@
+import { Menu } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+import { useNavItems } from '@/routes/navigation'
+
+export function HamburgerMenu() {
+  const navItems = useNavItems()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Menu" className="-ml-1">
+          <Menu className="size-5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuLabel>Navegação</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {navItems.map(item => (
+          <Link key={item.url} to={item.url}>
+            <DropdownMenuItem className="gap-2">
+              {item.icon && <item.icon className="size-4" />}
+              <span>{item.title}</span>
+            </DropdownMenuItem>
+          </Link>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/src/components/layout/header.tsx
+++ b/web/src/components/layout/header.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Separator } from '@/components/ui/separator'
-import { SidebarTrigger } from '@/components/ui/sidebar'
+import { HamburgerMenu } from '@/components/layout/hamburger-menu'
 import { useActiveOrganization } from '@/hooks/use-active-organization'
 import { useSidebar } from '@/hooks/use-sidebar'
 import { useGetInvite } from '@/http/generated/api'
@@ -21,7 +21,7 @@ export function Header() {
   return (
     <header className="bg-background sticky top-0 flex shrink-0 items-center gap-2 border-b p-1 z-50">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6 group-data-[collapsible=icon]:hidden">
-        <SidebarTrigger className="-ml-1" />
+        <HamburgerMenu />
         <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
         <p>{route?.title}</p>
       </div>


### PR DESCRIPTION
## Summary
- add hamburger menu component with navigation links
- integrate hamburger menu into header

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689cb29849b483338adbf47f0139586f