### PR TITLE
feat: add notification schemas and utils

### DIFF
--- a/api/.migrations/0001_create_notifications.sql
+++ b/api/.migrations/0001_create_notifications.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS notification_policies (
+  id serial PRIMARY KEY,
+  org_id varchar NOT NULL,
+  scope varchar(16) NOT NULL,
+  event varchar(16) NOT NULL,
+  days_before integer,
+  days_overdue integer,
+  repeat_every_minutes integer,
+  max_occurrences integer,
+  channels varchar(64) NOT NULL,
+  type_filter varchar(16),
+  category_id varchar,
+  amount_min numeric,
+  amount_max numeric,
+  quiet_hours_start time,
+  quiet_hours_end time,
+  timezone varchar(64) DEFAULT 'America/Sao_Paulo',
+  weekdays_mask integer DEFAULT 127,
+  active boolean DEFAULT true,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX notification_policies_org_idx ON notification_policies(org_id);
+
+CREATE TABLE IF NOT EXISTS notification_state (
+  id serial PRIMARY KEY,
+  policy_id integer NOT NULL REFERENCES notification_policies(id) ON DELETE CASCADE,
+  resource_type varchar(16) NOT NULL,
+  resource_id varchar NOT NULL,
+  last_notified_at timestamp with time zone,
+  occurrences integer DEFAULT 0,
+  next_eligible_at timestamp with time zone,
+  status varchar(16) DEFAULT 'ok'
+);
+
+CREATE UNIQUE INDEX notification_state_policy_resource_idx
+  ON notification_state(policy_id, resource_type, resource_id);
+
+CREATE TABLE IF NOT EXISTS notification_runs (
+  id serial PRIMARY KEY,
+  policy_id integer REFERENCES notification_policies(id) ON DELETE CASCADE,
+  resource_type varchar(16),
+  resource_id varchar,
+  channel varchar(16),
+  sent_at timestamp with time zone NOT NULL,
+  status varchar(16),
+  error text
+);

--- a/api/src/db/schemas/notificationPolicies.ts
+++ b/api/src/db/schemas/notificationPolicies.ts
@@ -1,0 +1,34 @@
+import { pgTable, serial, text, varchar, integer, boolean, numeric, time, timestamp, index } from 'drizzle-orm/pg-core'
+
+/** Notification policies configuration */
+export const notificationPolicies = pgTable(
+  'notification_policies',
+  {
+    id: serial('id').primaryKey(),
+    orgId: varchar('org_id').notNull(),
+    scope: varchar('scope', { length: 16 }).notNull(),
+    event: varchar('event', { length: 16 }).notNull(),
+    daysBefore: integer('days_before'),
+    daysOverdue: integer('days_overdue'),
+    repeatEveryMinutes: integer('repeat_every_minutes'),
+    maxOccurrences: integer('max_occurrences'),
+    channels: varchar('channels', { length: 64 }).notNull(),
+    typeFilter: varchar('type_filter', { length: 16 }),
+    categoryId: varchar('category_id'),
+    amountMin: numeric('amount_min'),
+    amountMax: numeric('amount_max'),
+    quietHoursStart: time('quiet_hours_start'),
+    quietHoursEnd: time('quiet_hours_end'),
+    timezone: varchar('timezone', { length: 64 }).default('America/Sao_Paulo'),
+    weekdaysMask: integer('weekdays_mask').default(127),
+    active: boolean('active').default(true),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  },
+  table => ({
+    orgIdx: index('notification_policies_org_idx').on(table.orgId),
+  })
+)
+
+export type NotificationScope = 'transaction' | 'goal'
+export type NotificationEvent = 'due_soon' | 'overdue'

--- a/api/src/db/schemas/notificationRuns.ts
+++ b/api/src/db/schemas/notificationRuns.ts
@@ -1,0 +1,14 @@
+import { pgTable, serial, integer, varchar, text, timestamp } from 'drizzle-orm/pg-core'
+import { notificationPolicies } from './notificationPolicies'
+
+export const notificationRuns = pgTable('notification_runs', {
+  id: serial('id').primaryKey(),
+  policyId: integer('policy_id')
+    .references(() => notificationPolicies.id, { onDelete: 'cascade' }),
+  resourceType: varchar('resource_type', { length: 16 }),
+  resourceId: text('resource_id'),
+  channel: varchar('channel', { length: 16 }),
+  sentAt: timestamp('sent_at', { withTimezone: true }).notNull(),
+  status: varchar('status', { length: 16 }),
+  error: text('error'),
+})

--- a/api/src/db/schemas/notificationState.ts
+++ b/api/src/db/schemas/notificationState.ts
@@ -1,0 +1,25 @@
+import { pgTable, serial, integer, varchar, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core'
+import { notificationPolicies } from './notificationPolicies'
+
+export const notificationState = pgTable(
+  'notification_state',
+  {
+    id: serial('id').primaryKey(),
+    policyId: integer('policy_id')
+      .notNull()
+      .references(() => notificationPolicies.id, { onDelete: 'cascade' }),
+    resourceType: varchar('resource_type', { length: 16 }).notNull(),
+    resourceId: text('resource_id').notNull(),
+    lastNotifiedAt: timestamp('last_notified_at', { withTimezone: true }),
+    occurrences: integer('occurrences').default(0),
+    nextEligibleAt: timestamp('next_eligible_at', { withTimezone: true }),
+    status: varchar('status', { length: 16 }).default('ok'),
+  },
+  table => ({
+    policyResourceIdx: uniqueIndex('notification_state_policy_resource_idx').on(
+      table.policyId,
+      table.resourceType,
+      table.resourceId,
+    ),
+  }),
+)

--- a/api/src/domain/notifications/utils.test.ts
+++ b/api/src/domain/notifications/utils.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import dayjs from 'dayjs'
+import { calculateNextEligibleAt, isWithinQuietHours } from './utils'
+
+describe('isWithinQuietHours', () => {
+  it('detects range within same day', () => {
+    const now = dayjs('2024-01-01T23:00:00Z').toDate()
+    assert.equal(isWithinQuietHours(now, '22:00', '23:30', 'UTC'), true)
+  })
+
+  it('detects range crossing midnight', () => {
+    const now = dayjs('2024-01-02T01:00:00Z').toDate()
+    assert.equal(isWithinQuietHours(now, '22:00', '07:00', 'UTC'), true)
+  })
+
+  it('outside quiet hours', () => {
+    const now = dayjs('2024-01-02T08:00:00Z').toDate()
+    assert.equal(isWithinQuietHours(now, '22:00', '07:00', 'UTC'), false)
+  })
+})
+
+describe('calculateNextEligibleAt', () => {
+  it('returns null when repeat not set', () => {
+    assert.equal(calculateNextEligibleAt(new Date(), null), null)
+  })
+
+  it('adds minutes when repeat set', () => {
+    const last = dayjs('2024-01-01T00:00:00Z').toDate()
+    const next = calculateNextEligibleAt(last, 60)
+    assert.equal(dayjs(next!).toISOString(), dayjs(last).add(60, 'minute').toISOString())
+  })
+})

--- a/api/src/domain/notifications/utils.ts
+++ b/api/src/domain/notifications/utils.ts
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+/**
+ * Check if "now" is within quiet hours window considering timezone.
+ * If start > end the window crosses midnight.
+ */
+export function isWithinQuietHours(
+  now: Date,
+  start: string | null,
+  end: string | null,
+  tz: string,
+): boolean {
+  if (!start || !end) return false
+
+  const current = dayjs(now).tz(tz)
+  const [sh, sm] = start.split(':').map(Number)
+  const [eh, em] = end.split(':').map(Number)
+  const startTime = current.set('hour', sh).set('minute', sm).set('second', 0)
+  const endTime = current.set('hour', eh).set('minute', em).set('second', 0)
+
+  if (startTime.isSame(endTime)) return true
+  if (startTime.isBefore(endTime)) {
+    return current.isAfter(startTime) && current.isBefore(endTime)
+  }
+  // crosses midnight
+  return current.isAfter(startTime) || current.isBefore(endTime)
+}
+
+/**
+ * Compute next eligible time from last notification respecting repetition.
+ * Returns null when repeatEveryMinutes is null.
+ */
+export function calculateNextEligibleAt(
+  lastNotifiedAt: Date | null,
+  repeatEveryMinutes: number | null,
+): Date | null {
+  if (repeatEveryMinutes == null) return null
+  const base = lastNotifiedAt ? dayjs(lastNotifiedAt) : dayjs()
+  return base.add(repeatEveryMinutes, 'minute').toDate()
+}

--- a/web/src/http/notifications.ts
+++ b/web/src/http/notifications.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { http } from './client'
+
+export interface NotificationPolicy {
+  id: number
+  scope: 'transaction' | 'goal'
+  event: 'due_soon' | 'overdue'
+  days_before?: number | null
+  days_overdue?: number | null
+  repeat_every_minutes?: number | null
+  max_occurrences?: number | null
+  channels: string
+  active: boolean
+}
+
+export interface CreatePolicyInput {
+  scope: 'transaction' | 'goal'
+  event: 'due_soon' | 'overdue'
+  days_before?: number | null
+  days_overdue?: number | null
+  repeat_every_minutes?: number | null
+  max_occurrences?: number | null
+  channels: string
+  active?: boolean
+}
+
+export async function listPolicies(org: string) {
+  return http<NotificationPolicy[]>(`/api/notifications/${org}/policies`, {
+    method: 'GET',
+  })
+}
+
+export async function createPolicy(org: string, data: CreatePolicyInput) {
+  return http<NotificationPolicy>(`/api/notifications/${org}/policies`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export function useListPolicies(slug: string) {
+  return useQuery({
+    queryKey: ['notification-policies', slug],
+    queryFn: () => listPolicies(slug),
+  })
+}
+
+export function useCreatePolicy() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ slug, data }: { slug: string; data: CreatePolicyInput }) =>
+      createPolicy(slug, data),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['notification-policies', vars.slug] })
+    },
+  })
+}

--- a/web/src/pages/_app/$org/(notifications)/-components/create-policy-dialog.tsx
+++ b/web/src/pages/_app/$org/(notifications)/-components/create-policy-dialog.tsx
@@ -1,0 +1,208 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { IconPlus } from '@tabler/icons-react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Form, FormField, FormItem, FormLabel, FormControl } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { useActiveOrganization } from '@/hooks/use-active-organization'
+import { useCreatePolicy } from '@/http/notifications'
+
+const schema = z
+  .object({
+    scope: z.enum(['transaction', 'goal']),
+    event: z.enum(['due_soon', 'overdue']),
+    days_before: z.coerce.number().int().min(0).optional().nullable(),
+    days_overdue: z.coerce.number().int().min(0).optional().nullable(),
+    repeat_every_minutes: z.coerce.number().int().min(0).optional().nullable(),
+    max_occurrences: z.coerce.number().int().min(0).optional().nullable(),
+    channels: z.string().default('email'),
+    active: z.boolean().default(true),
+  })
+  .refine(
+    data =>
+      (data.event === 'due_soon' && data.days_before !== null && data.days_overdue == null) ||
+      (data.event === 'overdue' && data.days_overdue !== null && data.days_before == null),
+    { message: 'Defina apenas o campo correspondente ao evento.' }
+  )
+
+export type PolicyFormSchema = z.infer<typeof schema>
+
+export function CreatePolicyDialog() {
+  const { slug } = useActiveOrganization()
+  const form = useForm<PolicyFormSchema>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      scope: 'transaction',
+      event: 'due_soon',
+      channels: 'email',
+      active: true,
+    },
+  })
+
+  const { mutateAsync: createPolicy } = useCreatePolicy()
+
+  async function onSubmit(data: PolicyFormSchema) {
+    try {
+      await createPolicy({ slug, data })
+      toast.success('Policy criada!')
+    } catch (err) {
+      toast.error('Erro ao criar policy')
+    }
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <IconPlus /> Nova policy
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Criar policy</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="scope"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Escopo</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Tipo" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="transaction">Transação</SelectItem>
+                      <SelectItem value="goal">Meta</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="event"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Evento</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Evento" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="due_soon">A vencer</SelectItem>
+                      <SelectItem value="overdue">Vencida</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+
+            {form.watch('event') === 'due_soon' ? (
+              <FormField
+                control={form.control}
+                name="days_before"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Dias antes</FormLabel>
+                    <FormControl>
+                      <Input type="number" {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <FormField
+                control={form.control}
+                name="days_overdue"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Dias de atraso</FormLabel>
+                    <FormControl>
+                      <Input type="number" {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="repeat_every_minutes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Repetir a cada (min)</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="max_occurrences"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Máx. ocorrências</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="channels"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Canais</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="active"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2">
+                  <FormLabel>Ativa</FormLabel>
+                  <FormControl>
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <Button type="submit" className="w-full">
+              Salvar
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/pages/_app/$org/(notifications)/notifications.tsx
+++ b/web/src/pages/_app/$org/(notifications)/notifications.tsx
@@ -1,7 +1,20 @@
-import { useListPolicies } from '@/http/notifications'
+import { createFileRoute } from '@tanstack/react-router'
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { useActiveOrganization } from '@/hooks/use-active-organization'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useListPolicies } from '@/http/notifications'
 import { CreatePolicyDialog } from './-components/create-policy-dialog'
+
+export const Route = createFileRoute('/_app/$org/(notifications)/notifications')({
+  component: NotificationsPage,
+})
 
 export default function NotificationsPage() {
   const { slug } = useActiveOrganization()

--- a/web/src/pages/_app/$org/(notifications)/notifications.tsx
+++ b/web/src/pages/_app/$org/(notifications)/notifications.tsx
@@ -1,0 +1,39 @@
+import { useListPolicies } from '@/http/notifications'
+import { useActiveOrganization } from '@/hooks/use-active-organization'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { CreatePolicyDialog } from './-components/create-policy-dialog'
+
+export default function NotificationsPage() {
+  const { slug } = useActiveOrganization()
+  const { data } = useListPolicies(slug)
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Policies</h1>
+        <CreatePolicyDialog />
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Escopo</TableHead>
+            <TableHead>Evento</TableHead>
+            <TableHead>Repetição</TableHead>
+            <TableHead>Ativa</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data?.map(p => (
+            <TableRow key={p.id}>
+              <TableCell>{p.scope}</TableCell>
+              <TableCell>{p.event}</TableCell>
+              <TableCell>{p.repeat_every_minutes ?? '-'}</TableCell>
+              <TableCell>{p.active ? 'Sim' : 'Não'}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/web/src/pages/_app/$org/(transactions)/transactions.tsx
+++ b/web/src/pages/_app/$org/(transactions)/transactions.tsx
@@ -10,7 +10,7 @@ const startOfMonth = dayjs().startOf('month').format('YYYY-MM-DD')
 const endOfMonth = dayjs().endOf('month').format('YYYY-MM-DD')
 
 export const Route = createFileRoute('/_app/$org/(transactions)/transactions')({
-  component: Transaction,
+  component: Transactions,
   validateSearch: z.object({
     tags: z.array(z.string()).optional(),
     type: z.enum(['all', 'income', 'expense']).default('all'),
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/_app/$org/(transactions)/transactions')({
   }),
 })
 
-function Transaction() {
+function Transactions() {
   const { transactions, isPending } = useTransaction()
 
   if (isPending) {

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AuthSignInRouteImport } from './pages/_auth/sign-in'
 import { Route as AuthInviteRouteImport } from './pages/_auth/invite'
 import { Route as AppOrguserUsersRouteImport } from './pages/_app/$org/(user)/users'
 import { Route as AppOrgtransactionsTransactionsRouteImport } from './pages/_app/$org/(transactions)/transactions'
+import { Route as AppOrgnotificationsNotificationsRouteImport } from './pages/_app/$org/(notifications)/notifications'
 import { Route as AppOrggoalGoalsRouteImport } from './pages/_app/$org/(goal)/goals'
 import { Route as AppOrgdashboardDashboardRouteImport } from './pages/_app/$org/(dashboard)/dashboard'
 
@@ -59,6 +60,12 @@ const AppOrgtransactionsTransactionsRoute =
     path: '/$org/transactions',
     getParentRoute: () => AppLayoutRoute,
   } as any)
+const AppOrgnotificationsNotificationsRoute =
+  AppOrgnotificationsNotificationsRouteImport.update({
+    id: '/$org/(notifications)/notifications',
+    path: '/$org/notifications',
+    getParentRoute: () => AppLayoutRoute,
+  } as any)
 const AppOrggoalGoalsRoute = AppOrggoalGoalsRouteImport.update({
   id: '/$org/(goal)/goals',
   path: '/$org/goals',
@@ -78,6 +85,7 @@ export interface FileRoutesByFullPath {
   '/validate': typeof AuthValidateRoute
   '/$org/dashboard': typeof AppOrgdashboardDashboardRoute
   '/$org/goals': typeof AppOrggoalGoalsRoute
+  '/$org/notifications': typeof AppOrgnotificationsNotificationsRoute
   '/$org/transactions': typeof AppOrgtransactionsTransactionsRoute
   '/$org/users': typeof AppOrguserUsersRoute
 }
@@ -88,6 +96,7 @@ export interface FileRoutesByTo {
   '/validate': typeof AuthValidateRoute
   '/$org/dashboard': typeof AppOrgdashboardDashboardRoute
   '/$org/goals': typeof AppOrggoalGoalsRoute
+  '/$org/notifications': typeof AppOrgnotificationsNotificationsRoute
   '/$org/transactions': typeof AppOrgtransactionsTransactionsRoute
   '/$org/users': typeof AppOrguserUsersRoute
 }
@@ -101,6 +110,7 @@ export interface FileRoutesById {
   '/_auth/validate': typeof AuthValidateRoute
   '/_app/$org/(dashboard)/dashboard': typeof AppOrgdashboardDashboardRoute
   '/_app/$org/(goal)/goals': typeof AppOrggoalGoalsRoute
+  '/_app/$org/(notifications)/notifications': typeof AppOrgnotificationsNotificationsRoute
   '/_app/$org/(transactions)/transactions': typeof AppOrgtransactionsTransactionsRoute
   '/_app/$org/(user)/users': typeof AppOrguserUsersRoute
 }
@@ -113,6 +123,7 @@ export interface FileRouteTypes {
     | '/validate'
     | '/$org/dashboard'
     | '/$org/goals'
+    | '/$org/notifications'
     | '/$org/transactions'
     | '/$org/users'
   fileRoutesByTo: FileRoutesByTo
@@ -123,6 +134,7 @@ export interface FileRouteTypes {
     | '/validate'
     | '/$org/dashboard'
     | '/$org/goals'
+    | '/$org/notifications'
     | '/$org/transactions'
     | '/$org/users'
   id:
@@ -135,6 +147,7 @@ export interface FileRouteTypes {
     | '/_auth/validate'
     | '/_app/$org/(dashboard)/dashboard'
     | '/_app/$org/(goal)/goals'
+    | '/_app/$org/(notifications)/notifications'
     | '/_app/$org/(transactions)/transactions'
     | '/_app/$org/(user)/users'
   fileRoutesById: FileRoutesById
@@ -202,6 +215,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgtransactionsTransactionsRouteImport
       parentRoute: typeof AppLayoutRoute
     }
+    '/_app/$org/(notifications)/notifications': {
+      id: '/_app/$org/(notifications)/notifications'
+      path: '/$org/notifications'
+      fullPath: '/$org/notifications'
+      preLoaderRoute: typeof AppOrgnotificationsNotificationsRouteImport
+      parentRoute: typeof AppLayoutRoute
+    }
     '/_app/$org/(goal)/goals': {
       id: '/_app/$org/(goal)/goals'
       path: '/$org/goals'
@@ -222,6 +242,7 @@ declare module '@tanstack/react-router' {
 interface AppLayoutRouteChildren {
   AppOrgdashboardDashboardRoute: typeof AppOrgdashboardDashboardRoute
   AppOrggoalGoalsRoute: typeof AppOrggoalGoalsRoute
+  AppOrgnotificationsNotificationsRoute: typeof AppOrgnotificationsNotificationsRoute
   AppOrgtransactionsTransactionsRoute: typeof AppOrgtransactionsTransactionsRoute
   AppOrguserUsersRoute: typeof AppOrguserUsersRoute
 }
@@ -229,6 +250,7 @@ interface AppLayoutRouteChildren {
 const AppLayoutRouteChildren: AppLayoutRouteChildren = {
   AppOrgdashboardDashboardRoute: AppOrgdashboardDashboardRoute,
   AppOrggoalGoalsRoute: AppOrggoalGoalsRoute,
+  AppOrgnotificationsNotificationsRoute: AppOrgnotificationsNotificationsRoute,
   AppOrgtransactionsTransactionsRoute: AppOrgtransactionsTransactionsRoute,
   AppOrguserUsersRoute: AppOrguserUsersRoute,
 }

--- a/web/src/routes/navigation.ts
+++ b/web/src/routes/navigation.ts
@@ -1,4 +1,4 @@
-import { CreditCard, LayoutDashboard, Rocket, Users } from 'lucide-react'
+import { Bell, CreditCard, LayoutDashboard, Rocket, Users } from 'lucide-react'
 
 import { useOrgStore } from '@/stores/org'
 
@@ -6,6 +6,7 @@ const baseItems = [
   { title: 'Dashboard', path: 'dashboard', icon: LayoutDashboard },
   { title: 'Metas', path: 'goals', icon: Rocket },
   { title: 'Transações', path: 'transactions', icon: CreditCard },
+  { title: 'Notificações', path: 'notifications', icon: Bell },
   { title: 'Usuários', path: 'users', icon: Users },
 ]
 


### PR DESCRIPTION
## Summary
- add database schemas and migration for notification policies
- implement quiet hour and next eligible helpers
- add simple tests for notification utilities
- add frontend list and creation UI for notification policies

## Testing
- `cd api && node --test --import tsx src/domain/notifications/utils.test.ts`
- `npm --prefix web run build` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d749c9d0833393d1c3366b98e259