### PR TITLE
fix: respect per-page table size

### DIFF
--- a/web/src/pages/_app/$org/(transactions)/-components/modal-new-transaction/due-date-field.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/modal-new-transaction/due-date-field.tsx
@@ -38,14 +38,7 @@ export function CalendarField({ form }: CalendarFieldProps) {
                   <ChevronDownIcon />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent
-                className="w-auto overflow-hidden p-0"
-                align="start"
-                onInteractOutside={e => {
-                  const target = e.target as HTMLElement
-                  if (target.closest('select')) e.preventDefault()
-                }}
-              >
+              <PopoverContent className="z-[90] w-auto overflow-hidden p-0 pointer-events-auto">
                 <Calendar
                   mode="single"
                   selected={field.value}

--- a/web/src/pages/_app/$org/(transactions)/-components/modal-new-transaction/due-date-field.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/modal-new-transaction/due-date-field.tsx
@@ -38,7 +38,14 @@ export function CalendarField({ form }: CalendarFieldProps) {
                   <ChevronDownIcon />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-auto overflow-hidden p-0" align="start">
+              <PopoverContent
+                className="w-auto overflow-hidden p-0"
+                align="start"
+                onInteractOutside={e => {
+                  const target = e.target as HTMLElement
+                  if (target.closest('select')) e.preventDefault()
+                }}
+              >
                 <Calendar
                   mode="single"
                   selected={field.value}

--- a/web/src/pages/_app/$org/(transactions)/-components/modal-new-transaction/pay-to-field.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/modal-new-transaction/pay-to-field.tsx
@@ -2,6 +2,7 @@ import { Check, ChevronsUpDown } from 'lucide-react'
 import * as React from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 
+import type { ListUsersByOrg200 } from '@/api/generated/model'
 import { Button } from '@/components/ui/button'
 import {
   Command,
@@ -14,7 +15,6 @@ import {
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Separator } from '@/components/ui/separator'
-import type { ListUsersByOrg200 } from '@/api/generated/model'
 import { cn } from '@/lib/utils'
 import { ModalNewUser } from '../../../../../../components/modal-new-user'
 import type { NewTransactionSchema } from './schema'
@@ -51,7 +51,7 @@ export function PayToField({ form, data }: PayToFieldProps) {
                   <ChevronsUpDown className="opacity-50" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-[200px] p-0">
+              <PopoverContent className="z-[90] w-[200px] p-0 verflow-hidden pointer-events-auto">
                 <Command>
                   <CommandInput placeholder="Pesquise o usuário..." className="h-9" />
                   <CommandList>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/delete-selected.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/delete-selected.tsx
@@ -1,6 +1,7 @@
 import type { Table } from '@tanstack/react-table'
 import { useState } from 'react'
 
+import { IconTrash } from '@tabler/icons-react'
 import type { ListTransactions200TransactionsItem } from '@/api/generated/model'
 import {
   AlertDialog,
@@ -35,8 +36,17 @@ export function DeleteSelected({ table }: Props) {
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button variant="destructive" size="sm">
-          Excluir selecionadas ({selected})
+        <Button
+          variant="destructive"
+          size="sm"
+          className="gap-1 px-2 sm:px-3"
+          aria-label={`Excluir ${selected} transação(ões)`}
+        >
+          <IconTrash size={16} />
+          <span className="sm:hidden" aria-hidden>
+            {selected}
+          </span>
+          <span className="hidden sm:inline">Excluir selecionadas ({selected})</span>
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
@@ -92,7 +92,7 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
         <DrawerHeader>
           <DrawerTitle>Editar transação</DrawerTitle>
         </DrawerHeader>
-        <div className="flex flex-col gap-4 p-4 overflow-y-auto">
+        <div className="flex flex-col gap-4 p-4 overflow-y-auto overflow-x-hidden">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(handleSubmit)} className="flex flex-col gap-4">
               <TypeField form={form} />

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/filter.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/filter.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from '@tanstack/react-router'
 import { ListFilterIcon } from 'lucide-react'
+import dayjs from 'dayjs'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -21,12 +22,25 @@ export interface FilterTableProps {
 export default function FilterTable({ type, dateFrom, dateTo }: FilterTableProps) {
   const navigate = useNavigate()
 
+  const defaultFrom = dayjs().startOf('month').format('YYYY-MM-DD')
+  const defaultTo = dayjs().endOf('month').format('YYYY-MM-DD')
+  const hasFilters =
+    type !== 'all' || dateFrom !== defaultFrom || dateTo !== defaultTo
+
   return (
     <div className="flex flex-col gap-4">
       <Popover>
         <PopoverTrigger asChild>
-          <Button variant="outline" size="icon" aria-label="Filters">
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Filters"
+            className="relative"
+          >
             <ListFilterIcon size={16} aria-hidden="true" />
+            {hasFilters && (
+              <span className="absolute -right-1 -top-1 block size-2 rounded-full bg-primary" />
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-80 p-3">

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/filter.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/filter.tsx
@@ -28,9 +28,8 @@ export default function FilterTable({ type, dateFrom, dateTo }: FilterTableProps
     type !== 'all' || dateFrom !== defaultFrom || dateTo !== defaultTo
 
   return (
-    <div className="flex flex-col gap-4">
-      <Popover>
-        <PopoverTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
           <Button
             variant="outline"
             size="icon"
@@ -39,58 +38,59 @@ export default function FilterTable({ type, dateFrom, dateTo }: FilterTableProps
           >
             <ListFilterIcon size={16} aria-hidden="true" />
             {hasFilters && (
-              <span className="absolute -right-1 -top-1 block size-2 rounded-full bg-primary" />
+              <span className="absolute -right-1 -top-1 block size-2 rounded-full bg-red-500" />
             )}
           </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-80 p-3">
-          <div className="flex flex-wrap items-end gap-2">
-            <Select
-              value={type}
-              onValueChange={(value = 'all') => {
-                navigate({
-                  to: '.',
-                  search: prev => ({ ...prev, type: value as typeof type, page: 1 }),
-                  replace: true,
-                })
-              }}
-            >
-              <SelectTrigger className="w-[180px]">
-                <SelectValue placeholder="Tipo" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todas</SelectItem>
-                <SelectItem value="income">Receitas</SelectItem>
-                <SelectItem value="expense">Despesas</SelectItem>
-              </SelectContent>
-            </Select>
+      </PopoverTrigger>
+      <PopoverContent className="w-[calc(100vw-2rem)] p-3 sm:w-80">
+        <div className="flex flex-wrap items-end gap-2">
+          <Select
+            value={type}
+            onValueChange={(value = 'all') => {
+              navigate({
+                to: '.',
+                search: prev => ({ ...prev, type: value as typeof type, page: 1 }),
+                replace: true,
+              })
+            }}
+          >
+            <SelectTrigger className="w-full sm:w-[180px]">
+              <SelectValue placeholder="Tipo" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todas</SelectItem>
+              <SelectItem value="income">Receitas</SelectItem>
+              <SelectItem value="expense">Despesas</SelectItem>
+            </SelectContent>
+          </Select>
 
-            <Input
-              type="date"
-              value={dateFrom}
-              onChange={e =>
-                navigate({
-                  to: '.',
-                  search: prev => ({ ...prev, dateFrom: e.target.value, page: 1 }),
-                  replace: true,
-                })
-              }
-            />
+          <Input
+            className="sm:w-auto"
+            type="date"
+            value={dateFrom}
+            onChange={e =>
+              navigate({
+                to: '.',
+                search: prev => ({ ...prev, dateFrom: e.target.value, page: 1 }),
+                replace: true,
+              })
+            }
+          />
 
-            <Input
-              type="date"
-              value={dateTo}
-              onChange={e =>
-                navigate({
-                  to: '.',
-                  search: prev => ({ ...prev, dateTo: e.target.value, page: 1 }),
-                  replace: true,
-                })
-              }
-            />
-          </div>
-        </PopoverContent>
-      </Popover>
-    </div>
+          <Input
+            className="sm:w-auto"
+            type="date"
+            value={dateTo}
+            onChange={e =>
+              navigate({
+                to: '.',
+                search: prev => ({ ...prev, dateTo: e.target.value, page: 1 }),
+                replace: true,
+              })
+            }
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/footer.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/footer.tsx
@@ -24,7 +24,7 @@ export interface FooterProps {
 
 export function Footer({ page, perPage, totalPages, onPerPageChange, onPageChange }: FooterProps) {
   return (
-    <div className="flex items-center justify-between px-4">
+    <div className="flex items-center justify-between px-4 lg:px-6">
       <div className="flex w-full items-center gap-8 lg:w-fit">
         <div className=" items-center gap-2 lg:flex">
           <Select

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/hook/use-table.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/hook/use-table.tsx
@@ -15,7 +15,7 @@ import {
 } from '@tanstack/react-table'
 import dayjs from 'dayjs'
 import { AlertOctagon, LucideClockFading, TrendingDown, TrendingUp } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import {
@@ -44,6 +44,7 @@ import { PayRowAction } from '../pay-row'
 
 export const useTable = (
   data: ListTransactions200TransactionsItem[],
+  perPage: number,
   onDuplicate?: (item: ListTransactions200TransactionsItem) => void
 ) => {
   const [rowSelection, setRowSelection] = useState({})
@@ -54,7 +55,7 @@ export const useTable = (
   const [sorting, setSorting] = useState<SortingState>([])
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 10,
+    pageSize: perPage,
   })
   const [editing, setEditing] = useState<ListTransactions200TransactionsItem | null>(null)
   const { slug } = useActiveOrganization()
@@ -97,6 +98,10 @@ export const useTable = (
   })
 
   const { mutateAsync: payTransaction } = usePayTransaction()
+
+  useEffect(() => {
+    setPagination({ pageIndex: 0, pageSize: perPage })
+  }, [perPage, data])
 
   function copyLink(id: string) {
     const url = `${window.location.origin}/transactions?openId=${id}`

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
@@ -19,7 +19,7 @@ export function TableLIstTransactions({ transactions, ...props }: Props) {
   const [draft, setDraft] = useState<ListTransactions200TransactionsItem | null>(null)
   const [openNew, setOpenNew] = useState(false)
 
-  const { table, editing, setEditing } = useTable(transactions, item => {
+  const { table, editing, setEditing } = useTable(transactions, props.perPage, item => {
     setDraft(item)
     setOpenNew(true)
   })

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
@@ -2,8 +2,6 @@ import type {
   ListTransactions200,
   ListTransactions200TransactionsItem,
 } from '@/api/generated/model'
-import dayjs from 'dayjs'
-import 'dayjs/locale/pt-br'
 import { useState } from 'react'
 import { DrawerEdit } from './drawer-edit'
 import type { FilterTableProps } from './filter'
@@ -26,20 +24,6 @@ export function TableLIstTransactions({ transactions, dateFrom, dateTo, ...props
     setOpenNew(true)
   })
 
-  const from = dayjs(dateFrom)
-  const to = dayjs(dateTo)
-  const isMonthRange =
-    from.isValid() &&
-    to.isValid() &&
-    from.isSame(to, 'month') &&
-    from.date() === 1 &&
-    to.date() === to.daysInMonth()
-  const rangeLabel = isMonthRange
-    ? from.locale('pt-br').format('MMMM [de] YYYY')
-    : from.isValid() && to.isValid()
-      ? `${from.locale('pt-br').format('DD/MM/YYYY')} - ${to.locale('pt-br').format('DD/MM/YYYY')}`
-      : ''
-
   return (
     <div className="flex flex-col gap-4">
       <NavbarTable
@@ -52,13 +36,6 @@ export function TableLIstTransactions({ transactions, dateFrom, dateTo, ...props
         dateFrom={dateFrom}
         dateTo={dateTo}
       />
-      {rangeLabel && (
-        <div className="px-4 lg:px-6">
-          <span className="text-sm text-muted-foreground capitalize">
-            {rangeLabel}
-          </span>
-        </div>
-      )}
       <TableView table={table} />
       <Footer {...props} />
       <DrawerNewTransaction

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/index.tsx
@@ -2,6 +2,8 @@ import type {
   ListTransactions200,
   ListTransactions200TransactionsItem,
 } from '@/api/generated/model'
+import dayjs from 'dayjs'
+import 'dayjs/locale/pt-br'
 import { useState } from 'react'
 import { DrawerEdit } from './drawer-edit'
 import type { FilterTableProps } from './filter'
@@ -15,7 +17,7 @@ interface Props extends FooterProps, FilterTableProps {
   transactions: ListTransactions200['transactions']
 }
 
-export function TableLIstTransactions({ transactions, ...props }: Props) {
+export function TableLIstTransactions({ transactions, dateFrom, dateTo, ...props }: Props) {
   const [draft, setDraft] = useState<ListTransactions200TransactionsItem | null>(null)
   const [openNew, setOpenNew] = useState(false)
 
@@ -23,6 +25,20 @@ export function TableLIstTransactions({ transactions, ...props }: Props) {
     setDraft(item)
     setOpenNew(true)
   })
+
+  const from = dayjs(dateFrom)
+  const to = dayjs(dateTo)
+  const isMonthRange =
+    from.isValid() &&
+    to.isValid() &&
+    from.isSame(to, 'month') &&
+    from.date() === 1 &&
+    to.date() === to.daysInMonth()
+  const rangeLabel = isMonthRange
+    ? from.locale('pt-br').format('MMMM [de] YYYY')
+    : from.isValid() && to.isValid()
+      ? `${from.locale('pt-br').format('DD/MM/YYYY')} - ${to.locale('pt-br').format('DD/MM/YYYY')}`
+      : ''
 
   return (
     <div className="flex flex-col gap-4">
@@ -32,8 +48,17 @@ export function TableLIstTransactions({ transactions, ...props }: Props) {
           setDraft(null)
           setOpenNew(true)
         }}
-        {...props}
+        type={props.type}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
       />
+      {rangeLabel && (
+        <div className="px-4 lg:px-6">
+          <span className="text-sm text-muted-foreground capitalize">
+            {rangeLabel}
+          </span>
+        </div>
+      )}
       <TableView table={table} />
       <Footer {...props} />
       <DrawerNewTransaction

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/navbar.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/navbar.tsx
@@ -1,5 +1,8 @@
-import { IconLayoutColumns, IconPlus } from '@tabler/icons-react'
+import { IconLayoutColumns, IconPlus, IconX } from '@tabler/icons-react'
+import { useNavigate } from '@tanstack/react-router'
 import type { Table } from '@tanstack/react-table'
+import dayjs from 'dayjs'
+import 'dayjs/locale/pt-br'
 
 import type { ListTransactions200TransactionsItem } from '@/api/generated/model'
 import { Button } from '@/components/ui/button'
@@ -19,9 +22,59 @@ interface Props extends FilterTableProps {
 }
 
 export function NavbarTable({ table, onCreate, ...props }: Props) {
+  const navigate = useNavigate()
+
+  const defaultFrom = dayjs().startOf('month').format('YYYY-MM-DD')
+  const defaultTo = dayjs().endOf('month').format('YYYY-MM-DD')
+  const hasFilters =
+    props.type !== 'all' || props.dateFrom !== defaultFrom || props.dateTo !== defaultTo
+
+  const from = dayjs(props.dateFrom)
+  const to = dayjs(props.dateTo)
+  const isMonthRange =
+    from.isValid() &&
+    to.isValid() &&
+    from.isSame(to, 'month') &&
+    from.date() === 1 &&
+    to.date() === to.daysInMonth()
+  const rangeLabel = isMonthRange
+    ? from.locale('pt-br').format('MMMM [de] YYYY')
+    : from.isValid() && to.isValid()
+      ? `${from.locale('pt-br').format('DD/MM/YYYY')} - ${to.locale('pt-br').format('DD/MM/YYYY')}`
+      : ''
+
   return (
-    <div className="flex items-center justify-between px-4 lg:px-6">
-      <FilterTable {...props} />
+    <div className="flex items-center justify-between gap-2 px-4 lg:px-6">
+      <div className="flex min-w-0 items-center gap-2">
+        <FilterTable {...props} />
+        {hasFilters && (
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Clear filters"
+            onClick={() => {
+              navigate({
+                to: '.',
+                search: prev => ({
+                  ...prev,
+                  type: 'all',
+                  dateFrom: defaultFrom,
+                  dateTo: defaultTo,
+                  page: 1,
+                }),
+                replace: true,
+              })
+            }}
+          >
+            <IconX size={16} />
+          </Button>
+        )}
+        {rangeLabel && (
+          <span className="hidden truncate text-sm text-muted-foreground capitalize sm:inline">
+            {rangeLabel}
+          </span>
+        )}
+      </div>
 
       <div className="flex items-center gap-2">
         <DropdownMenu>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/pay-selected.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/pay-selected.tsx
@@ -1,6 +1,7 @@
 import type { Table } from '@tanstack/react-table'
 import { useState } from 'react'
 
+import { IconCheck, IconX } from '@tabler/icons-react'
 import type { ListTransactions200TransactionsItem } from '@/api/generated/model'
 import {
   AlertDialog,
@@ -38,8 +39,24 @@ export function PaySelected({ table }: Props) {
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button size="sm">
-          {allPaid ? `Cancelar pagamento (${selected})` : `Pagar selecionadas (${selected})`}
+        <Button
+          size="sm"
+          className="gap-1 px-2 sm:px-3"
+          aria-label={
+            allPaid
+              ? `Cancelar pagamento de ${selected} transação(ões)`
+              : `Pagar ${selected} transação(ões)`
+          }
+        >
+          {allPaid ? <IconX size={16} /> : <IconCheck size={16} />}
+          <span className="sm:hidden" aria-hidden>
+            {selected}
+          </span>
+          <span className="hidden sm:inline">
+            {allPaid
+              ? `Cancelar pagamento (${selected})`
+              : `Pagar selecionadas (${selected})`}
+          </span>
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>


### PR DESCRIPTION
## Summary
- pass per-page option to transactions table
- keep table footer aligned with table content

## Testing
- `npm run lint` *(fails: noUnusedImports, noUnusedVariables, noExplicitAny, useUniqueElementIds, noUnknownAtRules)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e90130c8333bd2bc8e3ac5971dd