### PR TITLE
feat: handle recurring transaction updates and deletes

### DIFF
--- a/api/src/http/controllers/transaction/update-transaction.controller.ts
+++ b/api/src/http/controllers/transaction/update-transaction.controller.ts
@@ -29,6 +29,7 @@ export async function updateTransactionController(request: Req, reply: FastifyRe
     recurrenceUntil,
     recurrenceStart,
     installmentsTotal,
+    applyToSeries,
   } = request.body
   const { id } = request.params
 
@@ -56,6 +57,7 @@ export async function updateTransactionController(request: Req, reply: FastifyRe
     recurrenceUntil,
     recurrenceStart,
     installmentsTotal,
+    applyToSeries,
   })
 
   return reply.status(204).send(null)

--- a/api/src/http/schemas/transaction/update-transaction.schema.ts
+++ b/api/src/http/schemas/transaction/update-transaction.schema.ts
@@ -7,9 +7,11 @@ export const updateTransactionSchema = {
   description: 'Update a transaction',
   operationId: 'updateTransaction',
   params: z.object({ slug: z.string(), id: z.string() }),
-  body: newTransactionSchema.extend({
-    applyToSeries: z.boolean().default(true),
-  }),
+  body: newTransactionSchema.and(
+    z.object({
+      applyToSeries: z.boolean().default(true),
+    }),
+  ),
   response: {
     204: z.null(),
   },

--- a/api/src/http/schemas/transaction/update-transaction.schema.ts
+++ b/api/src/http/schemas/transaction/update-transaction.schema.ts
@@ -7,7 +7,9 @@ export const updateTransactionSchema = {
   description: 'Update a transaction',
   operationId: 'updateTransaction',
   params: z.object({ slug: z.string(), id: z.string() }),
-  body: newTransactionSchema,
+  body: newTransactionSchema.extend({
+    applyToSeries: z.boolean().default(true),
+  }),
   response: {
     204: z.null(),
   },

--- a/api/src/http/schemas/transaction/update-transaction.schema.ts
+++ b/api/src/http/schemas/transaction/update-transaction.schema.ts
@@ -1,22 +1,53 @@
 import z from 'zod'
 
-import { newTransactionSchema } from './create-transaction.schema'
+const base = z.object({
+  type: z.enum(['expense', 'income']).default('expense').nonoptional('O tipo é obrigatório'),
+  title: z.string('O título é obrigatório').min(1).max(50),
+  amount: z.coerce.number('Valor da transação é obrigatório').min(1),
+  dueDate: z.coerce.date({ error: 'A data de vencimento é obrigatória' }),
+  payToEmail: z.email('Defina o pra quem vai o registro'),
+  description: z.string().optional(),
+  tags: z
+    .array(z.object({ name: z.string().trim().min(1), color: z.string().trim().min(1) }))
+    .optional(),
+  applyToSeries: z.boolean().default(true),
+})
+
+const recurring = base.extend({
+  isRecurring: z.literal(true),
+  recurrenceSelector: z.enum(['date', 'repeat']).optional(),
+  recurrenceType: z.enum(['weekly', 'monthly', 'yearly', 'custom']).optional(),
+  recurrenceUntil: z.coerce.date().optional(),
+  recurrenceInterval: z.coerce.number().int().optional(),
+  recurrenceStart: z.coerce.date().optional(),
+  installmentsTotal: z.coerce.number().int().optional(),
+  installmentsPaid: z.coerce.number().int().optional(),
+})
+
+const nonRecurring = base.extend({
+  isRecurring: z.literal(false),
+  recurrenceSelector: z.undefined(),
+  recurrenceType: z.undefined(),
+  recurrenceUntil: z.undefined(),
+  recurrenceInterval: z.undefined(),
+  recurrenceStart: z.undefined(),
+  installmentsTotal: z.undefined(),
+  installmentsPaid: z.undefined(),
+})
+
+const bodySchema = z.discriminatedUnion('isRecurring', [recurring, nonRecurring])
 
 export const updateTransactionSchema = {
   tags: ['Transaction'],
   description: 'Update a transaction',
   operationId: 'updateTransaction',
   params: z.object({ slug: z.string(), id: z.string() }),
-  body: newTransactionSchema.and(
-    z.object({
-      applyToSeries: z.boolean().default(true),
-    }),
-  ),
+  body: bodySchema,
   response: {
     204: z.null(),
   },
 }
 
 export type UpdateTransactionSchemaParams = z.infer<typeof updateTransactionSchema.params>
-export type UpdateTransactionSchemaBody = z.infer<typeof updateTransactionSchema.body>
+export type UpdateTransactionSchemaBody = z.infer<typeof bodySchema>
 export type UpdateTransactionSchemaResponse = z.infer<typeof updateTransactionSchema.response>

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1000,6 +1000,10 @@
                         "type": "integer",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991
+                      },
+                      "applyToSeries": {
+                        "type": "boolean",
+                        "default": true
                       }
                     },
                     "required": [
@@ -1074,7 +1078,11 @@
                       "recurrenceInterval": {},
                       "recurrenceStart": {},
                       "installmentsTotal": {},
-                      "installmentsPaid": {}
+                      "installmentsPaid": {},
+                      "applyToSeries": {
+                        "type": "boolean",
+                        "default": true
+                      }
                     },
                     "required": [
                       "type",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1012,9 +1012,7 @@
                       "amount",
                       "dueDate",
                       "payToEmail",
-                      "isRecurring",
-                      "recurrenceSelector",
-                      "recurrenceType"
+                      "isRecurring"
                     ]
                   },
                   {

--- a/web/src/api/generated/model/updateTransactionBodyAnyOf.ts
+++ b/web/src/api/generated/model/updateTransactionBodyAnyOf.ts
@@ -39,9 +39,10 @@ export type UpdateTransactionBodyAnyOf = {
    * @maximum 9007199254740991
    */
   installmentsTotal?: number;
-  /**
-   * @minimum -9007199254740991
-   * @maximum 9007199254740991
-   */
-  installmentsPaid?: number;
-};
+    /**
+     * @minimum -9007199254740991
+     * @maximum 9007199254740991
+     */
+    installmentsPaid?: number;
+    applyToSeries?: boolean;
+  };

--- a/web/src/api/generated/model/updateTransactionBodyAnyOf.ts
+++ b/web/src/api/generated/model/updateTransactionBodyAnyOf.ts
@@ -25,8 +25,8 @@ export type UpdateTransactionBodyAnyOf = {
   description?: string;
   tags?: UpdateTransactionBodyAnyOfTagsItem[];
   isRecurring: boolean;
-  recurrenceSelector: UpdateTransactionBodyAnyOfRecurrenceSelector;
-  recurrenceType: UpdateTransactionBodyAnyOfRecurrenceType;
+  recurrenceSelector?: UpdateTransactionBodyAnyOfRecurrenceSelector;
+  recurrenceType?: UpdateTransactionBodyAnyOfRecurrenceType;
   recurrenceUntil?: unknown;
   /**
    * @minimum -9007199254740991

--- a/web/src/api/generated/model/updateTransactionBodyAnyOfSix.ts
+++ b/web/src/api/generated/model/updateTransactionBodyAnyOfSix.ts
@@ -27,7 +27,8 @@ export type UpdateTransactionBodyAnyOfSix = {
   recurrenceType?: unknown;
   recurrenceUntil?: unknown;
   recurrenceInterval?: unknown;
-  recurrenceStart?: unknown;
-  installmentsTotal?: unknown;
-  installmentsPaid?: unknown;
-};
+    recurrenceStart?: unknown;
+    installmentsTotal?: unknown;
+    installmentsPaid?: unknown;
+    applyToSeries?: boolean;
+  };

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/delete-row.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/delete-row.tsx
@@ -16,17 +16,20 @@ import {
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 
 interface Props {
-  id: string
+  transaction: ListTransactions200TransactionsItem
   table: Table<ListTransactions200TransactionsItem>
 }
 
-export function DeleteRowAction({ id, table }: Props) {
+export function DeleteRowAction({ transaction, table }: Props) {
   const [open, setOpen] = useState(false)
 
   function handleDelete() {
-    table.options.meta?.deleteRows([id])
+    table.options.meta?.deleteRows([transaction.id])
     setOpen(false)
   }
+
+  const isRecurring =
+    transaction.installmentsTotal == null || transaction.installmentsTotal > 1
 
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
@@ -37,7 +40,9 @@ export function DeleteRowAction({ id, table }: Props) {
         <AlertDialogHeader>
           <AlertDialogTitle>Excluir transação</AlertDialogTitle>
           <AlertDialogDescription>
-            Tem certeza que deseja excluir esta transação? Esta ação não pode ser desfeita.
+            {isRecurring
+              ? 'Esta transação faz parte de uma recorrência e todas as suas ocorrências serão excluídas. Deseja continuar?'
+              : 'Tem certeza que deseja excluir esta transação? Esta ação não pode ser desfeita.'}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/delete-selected.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/delete-selected.tsx
@@ -21,15 +21,20 @@ interface Props {
 }
 
 export function DeleteSelected({ table }: Props) {
-  const selected = table.getSelectedRowModel().rows.length
+  const rows = table.getSelectedRowModel().rows
+  const selected = rows.length
   const [open, setOpen] = useState(false)
 
   const handleDelete = () => {
-    const ids = table.getSelectedRowModel().rows.map(row => row.original.id)
+    const ids = rows.map(row => row.original.id)
     table.options.meta?.deleteRows(ids)
     table.resetRowSelection()
     setOpen(false)
   }
+
+  const hasRecurring = rows.some(
+    row => row.original.installmentsTotal == null || row.original.installmentsTotal > 1,
+  )
 
   if (selected === 0) return null
 
@@ -51,12 +56,14 @@ export function DeleteSelected({ table }: Props) {
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Excluir transações</AlertDialogTitle>
-          <AlertDialogDescription>
-            Tem certeza que deseja excluir {selected} transação(ões)? Esta ação não pode ser
-            desfeita.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+            <AlertDialogTitle>Excluir transações</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tem certeza que deseja excluir {selected} transação(ões)? Esta ação não pode ser
+              desfeita.
+              {hasRecurring &&
+                ' Transações recorrentes terão todas as suas ocorrências removidas.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancelar</AlertDialogCancel>
           <AlertDialogAction onClick={handleDelete}>Excluir</AlertDialogAction>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
@@ -69,12 +69,12 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
     })
   }, [transaction, form, data])
 
-  const { mutate: updateTransaction } = useUpdateTransaction({
-    mutation: {
-      onSuccess: () => {
-        toast.success('Transação atualizada com sucesso!')
-        queryClient.invalidateQueries({
-          queryKey: getListTransactionsQueryKey(slug),
+    const { mutate: updateTransaction } = useUpdateTransaction({
+      mutation: {
+        onSuccess: () => {
+          toast.success('Transação atualizada com sucesso!')
+          queryClient.invalidateQueries({
+            queryKey: getListTransactionsQueryKey(slug),
         })
         onOpenChange(false)
       },
@@ -82,10 +82,30 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
     },
   })
 
-  function handleSubmit(data: NewTransactionSchema) {
-    if (!transaction) return
-    updateTransaction({ slug, id: transaction.id, data })
-  }
+    function handleSubmit(data: NewTransactionSchema) {
+      if (!transaction) return
+
+      const isRecurring =
+        transaction.installmentsTotal == null || transaction.installmentsTotal > 1
+
+      let applyToSeries = true
+      if (isRecurring) {
+        applyToSeries = window.confirm(
+          'Esta transação é recorrente. Clique em OK para atualizar todas as ocorrências ou em Cancelar para atualizar apenas esta.',
+        )
+      }
+
+      updateTransaction({
+        slug,
+        id: transaction.id,
+        data: {
+          ...data,
+          isRecurring,
+          installmentsTotal: transaction.installmentsTotal ?? undefined,
+          applyToSeries,
+        } as any,
+      })
+    }
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange} direction={isMobile ? 'bottom' : 'right'}>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
@@ -132,13 +132,22 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
       if (!pendingData) return
       sendUpdate(pendingData, false)
       setConfirmOpen(false)
+      setPendingData(null)
     }
 
     function handleUpdateSeries() {
       if (!pendingData) return
       sendUpdate(pendingData, true)
       setConfirmOpen(false)
+      setPendingData(null)
     }
+
+    useEffect(() => {
+      if (!open) {
+        setConfirmOpen(false)
+        setPendingData(null)
+      }
+    }, [open])
 
   const isRecurring =
     transaction != null &&
@@ -186,8 +195,12 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel onClick={handleUpdateCurrent}>Apenas esta</AlertDialogCancel>
-              <AlertDialogAction onClick={handleUpdateSeries}>Toda a série</AlertDialogAction>
+              <AlertDialogCancel type="button" onClick={handleUpdateCurrent}>
+                Apenas esta
+              </AlertDialogCancel>
+              <AlertDialogAction type="button" onClick={handleUpdateSeries}>
+                Toda a série
+              </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
@@ -197,11 +197,15 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel type="button" onClick={handleUpdateCurrent}>
-                Apenas esta
+              <AlertDialogCancel asChild>
+                <Button type="button" variant="outline" onClick={handleUpdateCurrent}>
+                  Apenas esta
+                </Button>
               </AlertDialogCancel>
-              <AlertDialogAction type="button" onClick={handleUpdateSeries}>
-                Toda a série
+              <AlertDialogAction asChild>
+                <Button type="button" onClick={handleUpdateSeries}>
+                  Toda a série
+                </Button>
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/drawer-edit.tsx
@@ -97,7 +97,7 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
     function sendUpdate(data: NewTransactionSchema, applyToSeries: boolean) {
       if (!transaction) return
 
-      const isRecurring =
+      const isSeries =
         transaction.installmentsTotal == null || transaction.installmentsTotal > 1
 
       updateTransaction({
@@ -105,10 +105,12 @@ export function DrawerEdit({ transaction, open, onOpenChange }: Props) {
         id: transaction.id,
         data: {
           ...data,
-          isRecurring,
-          installmentsTotal: transaction.installmentsTotal ?? undefined,
+          isRecurring: applyToSeries && isSeries,
+          installmentsTotal: applyToSeries
+            ? transaction.installmentsTotal ?? undefined
+            : undefined,
           applyToSeries,
-        // biome-ignore lint/suspicious/noExplicitAny: API uses generated types
+          // biome-ignore lint/suspicious/noExplicitAny: API uses generated types
         } as any,
       })
     }

--- a/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/hook/use-table.tsx
+++ b/web/src/pages/_app/$org/(transactions)/-components/table-list-transactions/hook/use-table.tsx
@@ -292,12 +292,12 @@ export const useTable = (
             </DropdownMenuItem>
             <PayRowAction id={row.original.id} status={row.original.status} table={table} />
             <DropdownMenuSeparator />
-            <DeleteRowAction id={row.original.id} table={table} />
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ),
-    },
-  ]
+              <DeleteRowAction transaction={row.original} table={table} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ),
+      },
+    ]
 
   const table = useReactTable({
     data,


### PR DESCRIPTION
## Summary
- ask if recurring transactions should update one or all occurrences
- warn and remove entire recurring series when deleting
- support applyToSeries flag through API and client types

## Testing
- `pnpm lint` (fails: unused imports and other lint errors)
- `pnpm exec biome lint .`

------
https://chatgpt.com/codex/tasks/task_e_68a7b47e914c8333bb922255d922b980