### PR TITLE
feat: improve dashboard clarity and remove redundant card

### DIFF
--- a/web/src/pages/_app/$org/(dashboard)/components/MonthlyStatsCards.tsx
+++ b/web/src/pages/_app/$org/(dashboard)/components/MonthlyStatsCards.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, DollarSign, TrendingUp, Users } from 'lucide-react'
+import { AlertTriangle, TrendingUp, Users } from 'lucide-react'
 
 import type { GetOrgSlugReportsTransactions200ReportsMonthlyStats } from '@/api/generated/model'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -13,7 +13,7 @@ export function MonthlyStatsCards({ stats }: Props) {
 
   return (
     <div className="px-4 lg:px-6">
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total de Transações</CardTitle>
@@ -21,19 +21,6 @@ export function MonthlyStatsCards({ stats }: Props) {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{stats.totalTransactions}</div>
-            <p className="text-xs text-muted-foreground">Este mês</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Valor Total</CardTitle>
-            <DollarSign className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">
-              R$ {stats.totalAmount.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
-            </div>
             <p className="text-xs text-muted-foreground">Este mês</p>
           </CardContent>
         </Card>

--- a/web/src/pages/_app/$org/(dashboard)/components/TopBillsSummary.tsx
+++ b/web/src/pages/_app/$org/(dashboard)/components/TopBillsSummary.tsx
@@ -46,9 +46,9 @@ export function TopBillsSummary({ kpis }: Props) {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Sigma className="h-5 w-5 text-muted-foreground" /> Total do mês
+              <Sigma className="h-5 w-5 text-muted-foreground" /> Saldo do mês
             </CardTitle>
-            <CardDescription>Soma de valores registrados no mês</CardDescription>
+            <CardDescription>Saldo líquido (a receber - a pagar)</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-semibold">{format(totalMes)}</div>


### PR DESCRIPTION
- Rename 'Total do mês' to 'Saldo do mês' with clearer description
- Remove 'Valor Total' card that was confusing and not useful
- Adjust grid layout from 4 to 3 columns
- Clean up unused imports