### PR TITLE
fix: allow expense creditor to settle legacy null-createdBy txs

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houseapp",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "index.js",
   "scripts": {
     "dev": "tsx watch --env-file ./.env src/http/server.ts",

--- a/api/src/modules/transactions/can-settle-transaction.test.ts
+++ b/api/src/modules/transactions/can-settle-transaction.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { canSettleTransaction } from './can-settle-transaction'
+import { toTransactionViewer } from './transaction-visibility'
+
+describe('canSettleTransaction', () => {
+  const owner = toTransactionViewer('owner', 'owner')
+  const member = toTransactionViewer('member', 'owner')
+
+  it('allows the transaction creator', () => {
+    expect(canSettleTransaction(owner, 'owner', 'owner')).toBe(true)
+    expect(canSettleTransaction(member, 'member', 'owner')).toBe(true)
+  })
+
+  it('allows the expense creditor when createdBy is null (legacy)', () => {
+    expect(canSettleTransaction(owner, null, 'owner')).toBe(true)
+    expect(canSettleTransaction(member, null, 'owner')).toBe(false)
+  })
+
+  it('allows the expense creditor even when not the creator', () => {
+    expect(canSettleTransaction(member, 'owner', 'member')).toBe(true)
+  })
+
+  it('denies unrelated viewers', () => {
+    expect(canSettleTransaction(member, 'owner', 'owner')).toBe(false)
+    expect(canSettleTransaction(owner, 'member', 'member')).toBe(false)
+    expect(canSettleTransaction(owner, null, null)).toBe(false)
+  })
+})

--- a/api/src/modules/transactions/can-settle-transaction.ts
+++ b/api/src/modules/transactions/can-settle-transaction.ts
@@ -1,0 +1,14 @@
+import { canMutateTransaction, type TransactionViewer } from './transaction-visibility'
+
+/**
+ * Who may pay / cancel payment / schedule payment.
+ * Creator always; otherwise the expense creditor (legacy null createdBy → org owner).
+ */
+export function canSettleTransaction(
+  viewer: TransactionViewer,
+  createdBy: string | null | undefined,
+  creditorUserId: string | null | undefined
+): boolean {
+  if (canMutateTransaction(viewer, createdBy)) return true
+  return creditorUserId != null && creditorUserId === viewer.userId
+}

--- a/api/src/modules/transactions/transaction.service.ts
+++ b/api/src/modules/transactions/transaction.service.ts
@@ -27,11 +27,13 @@ import {
 import type { CategoryRepository } from '@/modules/categories/category.repository'
 import type { AccountRepository } from '@/modules/accounts/account.repository'
 import type { SplitService } from '@/modules/splits/split.service'
+import { loadExpenseCreditorUserId } from '@/modules/splits/load-expense-creditor'
 import type { StatementRepository } from '@/modules/statements/statement.repository'
 import {
   matchesInstallmentSeries,
   selectInstallmentSeriesSiblings,
 } from '@/modules/splits/split-debt-summary.logic'
+import { canSettleTransaction } from './can-settle-transaction'
 
 import type {
   ListTransactionsFilter,
@@ -568,7 +570,7 @@ export class TransactionService {
       throw notFound('Transaction not found')
     }
 
-    this.assertCanMutate(viewer, existing.createdBy)
+    await this.assertCanSettle(existing, viewer)
 
     if (existing.status === 'canceled') {
       throw badRequest('Cannot cancel payment on a canceled transaction')
@@ -635,8 +637,6 @@ export class TransactionService {
       throw notFound('Transaction not found')
     }
 
-    this.assertCanMutate(viewer, transaction.createdBy)
-
     if (
       transaction.installmentsTotal != null &&
       transaction.installmentsTotal >= 2 &&
@@ -646,6 +646,8 @@ export class TransactionService {
       transaction =
         (await this.transactionRepository.findById(organizationId, id, viewer)) ?? transaction
     }
+
+    await this.assertCanSettle(transaction, viewer)
 
     if (transaction.status === 'canceled') {
       throw badRequest('Cannot pay a canceled transaction')
@@ -827,7 +829,7 @@ export class TransactionService {
       throw notFound('Transaction not found')
     }
 
-    this.assertCanMutate(viewer, existing.createdBy)
+    await this.assertCanSettle(existing, viewer)
 
     if (existing.status === 'paid' || existing.status === 'canceled') {
       throw badRequest('Cannot schedule payment on a paid or canceled transaction')
@@ -855,7 +857,7 @@ export class TransactionService {
       throw notFound('Transaction not found')
     }
 
-    this.assertCanMutate(viewer, existing.createdBy)
+    await this.assertCanSettle(existing, viewer)
 
     if (!existing.paymentScheduledAt) {
       throw badRequest('Transaction has no scheduled payment')
@@ -883,7 +885,7 @@ export class TransactionService {
       throw notFound('Transaction not found')
     }
 
-    this.assertCanMutate(viewer, anchor.createdBy)
+    await this.assertCanSettle(anchor, viewer)
 
     if (anchor.status === 'canceled') {
       throw badRequest('Cannot pay a canceled transaction')
@@ -1556,6 +1558,22 @@ export class TransactionService {
     if (!viewer) return
     if (!canMutateTransaction(viewer, createdBy)) {
       throw forbidden('You can only modify transactions you created')
+    }
+  }
+
+  /** Pay / cancel / schedule — creator or expense creditor (legacy null createdBy). */
+  private async assertCanSettle(
+    transaction: {
+      cardId: string | null
+      accountId: string | null
+      createdBy: string | null
+    },
+    viewer?: TransactionViewer
+  ) {
+    if (!viewer) return
+    const creditorId = await loadExpenseCreditorUserId(transaction, viewer.ownerId)
+    if (!canSettleTransaction(viewer, transaction.createdBy, creditorId)) {
+      throw forbidden('You can only settle transactions you created or manage')
     }
   }
 

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HouseApp API",
     "description": "API for HouseApp",
-    "version": "2.3.2"
+    "version": "2.3.3"
   },
   "components": {
     "securitySchemes": {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HouseApp",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Notificações e resumo financeiro do HouseApp",
   "permissions": [
     "alarms",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houseapp-monorepo",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "workspaces": [
     "api",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houseapp-web",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Pay/cancel/schedule required the creator, so installments with null createdBy could register split receipts but not be marked paid. Align settlement with expense-creditor rules and bump to 2.3.3.