### PR TITLE
fix: clarify split vs bank status on transaction list and footer

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houseapp",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "index.js",
   "scripts": {
     "dev": "tsx watch --env-file ./.env src/http/server.ts",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "HouseApp API",
     "description": "API for HouseApp",
-    "version": "2.3.3"
+    "version": "2.3.4"
   },
   "components": {
     "securitySchemes": {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HouseApp",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Notificações e resumo financeiro do HouseApp",
   "permissions": [
     "alarms",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houseapp-monorepo",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": true,
   "workspaces": [
     "api",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houseapp-web",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/features/transactions/components/transaction-footer-summary/viewer-share.test.ts
+++ b/web/src/features/transactions/components/transaction-footer-summary/viewer-share.test.ts
@@ -85,6 +85,91 @@ describe('countPendingForViewer', () => {
       )
     ).toBe(1)
   })
+
+  it('scopes creditor pending to the current installment only', () => {
+    expect(
+      countPendingForViewer(
+        summary({
+          myShareTotal: '0.00',
+          viewerIsCreditor: true,
+          installmentsTotal: 10,
+          currentInstallmentNumber: 6,
+          persons: [
+            {
+              key: 'user:k',
+              name: 'Karoline',
+              userId: 'k',
+              contactName: null,
+              contactPhone: null,
+              totalOwed: '5560.90',
+              totalPaid: '3336.54',
+              totalRemaining: '2224.36',
+              status: 'partial',
+              isViewer: false,
+              installments: [
+                {
+                  installmentNumber: 6,
+                  transactionId: 'tx-6',
+                  transactionAmount: '556.09',
+                  splitId: 's-6',
+                  amount: '556.09',
+                  paidAmount: '556.09',
+                  status: 'paid',
+                },
+                {
+                  installmentNumber: 7,
+                  transactionId: 'tx-7',
+                  transactionAmount: '556.09',
+                  splitId: 's-7',
+                  amount: '556.09',
+                  paidAmount: '0.00',
+                  status: 'pending',
+                },
+              ],
+            },
+          ],
+        })
+      )
+    ).toBe(0)
+  })
+
+  it('counts creditor pending when the current installment is still open', () => {
+    expect(
+      countPendingForViewer(
+        summary({
+          myShareTotal: '0.00',
+          viewerIsCreditor: true,
+          installmentsTotal: 10,
+          currentInstallmentNumber: 7,
+          persons: [
+            {
+              key: 'user:k',
+              name: 'Karoline',
+              userId: 'k',
+              contactName: null,
+              contactPhone: null,
+              totalOwed: '5560.90',
+              totalPaid: '3336.54',
+              totalRemaining: '2224.36',
+              status: 'partial',
+              isViewer: false,
+              installments: [
+                {
+                  installmentNumber: 7,
+                  transactionId: 'tx-7',
+                  transactionAmount: '556.09',
+                  splitId: 's-7',
+                  amount: '556.09',
+                  paidAmount: '0.00',
+                  status: 'pending',
+                },
+              ],
+            },
+          ],
+        })
+      )
+    ).toBe(1)
+  })
 })
 
 describe('personDisplayName', () => {

--- a/web/src/features/transactions/components/transaction-footer-summary/viewer-share.ts
+++ b/web/src/features/transactions/components/transaction-footer-summary/viewer-share.ts
@@ -3,6 +3,15 @@ import { moneyStringToReais, reaisToMoneyString } from '@/lib/currency'
 
 import { resolvePersonShareInstallmentAmountReais } from '../../split-debt-summary.utils'
 
+function installmentHasOpenBalance(item: {
+  amount: string
+  paidAmount: string
+  status: string
+}): boolean {
+  if (item.status === 'paid' || item.status === 'forgiven') return false
+  return moneyStringToReais(item.amount) - moneyStringToReais(item.paidAmount) > 0.005
+}
+
 /** Primary “Meu valor” for the authenticated viewer (creditor residual vs debtor share). */
 export function resolveViewerMyShare(summary: GetSplitDebtSummary200): {
   amount: string
@@ -68,12 +77,31 @@ export function resolveViewerInstallmentAmount(
   }
 }
 
+/**
+ * Pending chip for the collapsed footer — scoped to the current installment when
+ * known, so a paid parcel 6 does not show “1 pendente” for future parcels 7–10.
+ */
 export function countPendingForViewer(summary: GetSplitDebtSummary200): number {
+  const current = summary.currentInstallmentNumber
+
   if (!summary.viewerIsCreditor) {
+    if (current != null) {
+      const viewer = summary.persons.find(person => person.isViewer)
+      const row = viewer?.installments.find(item => item.installmentNumber === current)
+      if (row) return installmentHasOpenBalance(row) ? 1 : 0
+    }
     const remaining = summary.viewerRemainingTotal
     if (remaining == null) return 0
     return moneyStringToReais(remaining) > 0 ? 1 : 0
   }
+
+  if (current != null) {
+    return summary.persons.filter(person => {
+      const row = person.installments.find(item => item.installmentNumber === current)
+      return row ? installmentHasOpenBalance(row) : false
+    }).length
+  }
+
   return summary.persons.filter(person => moneyStringToReais(person.totalRemaining) > 0).length
 }
 

--- a/web/src/features/transactions/components/transaction-list.tsx
+++ b/web/src/features/transactions/components/transaction-list.tsx
@@ -573,6 +573,15 @@ function TransactionTable({
             const overdue = mode === 'overdue' && isOverdue(tx)
             const payableListDate = !isCreditCardStatement ? getPayableListDate(tx) : null
             const creditCardExpense = isCreditCardExpense(tx, accounts?.accounts)
+            const hasSplit =
+              Boolean(fullyDelegatedById?.has(tx.id)) || Boolean(partiallyDividedById?.has(tx.id))
+            const splitSettlement = resolveTransactionSplitBadgeSettlement({
+              transactionId: tx.id,
+              hasSplit,
+              splitRemainingById,
+              viewerShareRemaining: viewerShareById?.get(tx.id)?.remainingAmount,
+            })
+            const reimbursementReceived = splitSettlement === 'received'
             const showRecurringContractButton = tx.recurringTransactionId != null
             const showPayButton =
               showPayActionColumn && tx.status === 'pending' && !creditCardExpense
@@ -625,14 +634,7 @@ function TransactionTable({
                       {tx.title}
                     </span>
                     {(() => {
-                      const hasSplit =
-                        fullyDelegatedById?.has(tx.id) || partiallyDividedById?.has(tx.id)
-                      const settlement = resolveTransactionSplitBadgeSettlement({
-                        transactionId: tx.id,
-                        hasSplit: Boolean(hasSplit),
-                        splitRemainingById,
-                        viewerShareRemaining: viewerShareById?.get(tx.id)?.remainingAmount,
-                      })
+                      const settlement = splitSettlement
                       const delegated = fullyDelegatedById?.get(tx.id)
                       if (delegated) {
                         const perspective = resolveSplitBadgePerspective(
@@ -745,6 +747,7 @@ function TransactionTable({
                           splitPaidById?.get(tx.id) ?? 0
                         ),
                         settlementKind: tx.type === 'income' ? 'income' : 'expense',
+                        reimbursementReceived,
                       }).map(badge => (
                         <Badge
                           key={badge.key}

--- a/web/src/features/transactions/lib/payable-status.test.ts
+++ b/web/src/features/transactions/lib/payable-status.test.ts
@@ -61,6 +61,27 @@ describe('payable-status', () => {
   it('formats overdue days', () => {
     assert.equal(formatOverdueDays(1), 'Vencida há 1 dia')
     assert.equal(formatOverdueDays(5), 'Vencida há 5 dias')
+    assert.equal(formatOverdueDays(6, { bankBill: true }), 'Conta vencida há 6 dias')
+  })
+
+  it('clarifies bank overdue when reimbursement already received', () => {
+    const tx = {
+      status: 'pending',
+      date: '2026-07-17T00:00:00.000Z',
+    }
+    const badges = getPayableStatusBadges(tx, { reimbursementReceived: true })
+    assert.equal(badges[0].key, 'overdue')
+    assert.match(badges[0].label, /^Conta vencida há/)
+  })
+
+  it('shows Pagar na conta when reimbursement received and not overdue', () => {
+    const tx = {
+      status: 'pending',
+      date: dayjs().startOf('day').toISOString(),
+    }
+    const badges = getPayableStatusBadges(tx, { reimbursementReceived: true })
+    assert.equal(badges[0].key, 'upcoming')
+    assert.equal(badges[0].label, 'Pagar conta hoje')
   })
 
   it('shows upcoming badge for pending due in the future', () => {

--- a/web/src/features/transactions/lib/payable-status.ts
+++ b/web/src/features/transactions/lib/payable-status.ts
@@ -21,6 +21,8 @@ export function isFutureScheduled(tx: PayableStatusTx): boolean {
 export type PayableStatusOptions = {
   isPartiallyPaid?: boolean
   settlementKind?: 'income' | 'expense'
+  /** Split reimbursement settled; bank payable may still be open. */
+  reimbursementReceived?: boolean
 }
 
 export function isOverduePayable(tx: PayableStatusTx): boolean {
@@ -28,7 +30,11 @@ export function isOverduePayable(tx: PayableStatusTx): boolean {
   return dayjs(tx.date).isBefore(dayjs().startOf('day'))
 }
 
-export function formatOverdueDays(days: number): string {
+export function formatOverdueDays(days: number, options?: { bankBill?: boolean }): string {
+  if (options?.bankBill) {
+    if (days === 1) return 'Conta vencida há 1 dia'
+    return `Conta vencida há ${days} dias`
+  }
   if (days === 1) return 'Vencida há 1 dia'
   return `Vencida há ${days} dias`
 }
@@ -90,7 +96,9 @@ export function getPayableStatusBadges(
     if (overdueDays != null) {
       badges.push({
         key: 'overdue',
-        label: formatOverdueDays(overdueDays),
+        label: formatOverdueDays(overdueDays, {
+          bankBill: options?.reimbursementReceived,
+        }),
         className: 'border-red-200 bg-red-50 text-red-800 hover:bg-red-50',
       })
     }
@@ -99,7 +107,13 @@ export function getPayableStatusBadges(
     if (daysUntilDue != null) {
       badges.push({
         key: 'upcoming',
-        label: formatUpcomingDays(daysUntilDue),
+        label: options?.reimbursementReceived
+          ? daysUntilDue === 0
+            ? 'Pagar conta hoje'
+            : daysUntilDue === 1
+              ? 'Pagar conta amanhã'
+              : `Pagar conta em ${daysUntilDue} dias`
+          : formatUpcomingDays(daysUntilDue),
         className: 'border-yellow-200 bg-yellow-50 text-yellow-800 hover:bg-yellow-50',
       })
     }
@@ -108,7 +122,7 @@ export function getPayableStatusBadges(
   if (badges.length === 0) {
     badges.push({
       key: 'pending',
-      label: 'Pendente',
+      label: options?.reimbursementReceived ? 'Pagar na conta' : 'Pendente',
       className: 'border-slate-200 bg-white text-slate-700',
     })
   }


### PR DESCRIPTION
Scope the Divisões pending chip to the current installment, and label bank overdue distinctly when reimbursement is already received. Bump to 2.3.4.